### PR TITLE
Live check-in tracking, email digest, web viewer, systemd deploy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,40 @@
-API_KEY= 
+# --- Galaxy Digital ---
+API_KEY=
 EMAIL=
 PASSWORD=
+
+# --- Google Calendar ---
 CLIENT_ID=
 CLIENT_SECRET=
 CALENDAR_ID=
+
+# --- Slack failure notifications (optional) ---
 WEBHOOK_URL=
-```
+
+# --- SQLite store ---
+GALAXY_DB_PATH=galaxy_sync.sqlite3
+
+# --- Digest email (optional; leave DIGEST_EMAIL_TO blank to disable) ---
+DIGEST_EMAIL_TO=
+DIGEST_EMAIL_FROM=
+DIGEST_SUBJECT_PREFIX=Galaxy Digital
+DIGEST_LOOKBACK_DAYS=1
+DIGEST_REPEAT_WINDOW=30
+DIGEST_REPEAT_MIN=2
+# Cadence: daily@HH:MM | hourly | off
+DIGEST_SCHEDULE=daily@21:00
+
+# --- SMTP (used only when DIGEST_EMAIL_TO is set) ---
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_TLS=yes
+
+# --- Web viewer ---
+# REQUIRED to enable the page; without it the server returns 503.
+WEB_PASSWORD=
+WEB_USERNAME=volunteer
+WEB_HOST=127.0.0.1
+WEB_PORT=8765
+WEB_REFRESH_SECS=60

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 credentials.json
 token.json
 
+# Runtime state -- contains volunteer PII, never commit
+transformed_responses.json
+*.sqlite3
+*.sqlite3-*
+debug.log
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,163 @@
+# Deploying to a Linux VM
+
+End-to-end procedure to get the sync loop and live web viewer auto-starting
+on boot. Tested on Debian/Ubuntu with systemd; should work on any modern
+systemd distro.
+
+## 1. Get the code onto the box
+
+```bash
+ssh debmin@<vm>
+cd ~
+git clone https://github.com/nkwsy/galaxy_digital_gcal_sync.git
+cd galaxy_digital_gcal_sync
+git checkout claude/sleepy-beaver-2c133a    # or the merged main once the PR lands
+```
+
+## 2. Bootstrap the virtualenv
+
+```bash
+./bootstrap.sh                  # creates env/, installs deps
+source env/bin/activate
+```
+
+## 3. Drop the secrets in
+
+```bash
+cp .env.example .env
+$EDITOR .env
+```
+
+At minimum set:
+
+| Variable | What for |
+|---|---|
+| `API_KEY` / `EMAIL` / `PASSWORD` | Galaxy Digital API user |
+| `CALENDAR_ID` | Production Google Calendar id |
+| `WEB_PASSWORD` | Required -- web viewer refuses 100% of requests without it |
+| `WEB_HOST` | `127.0.0.1` (default) or `0.0.0.0` if you'll reverse-proxy |
+| `WEB_PORT` | `8765` (default) |
+| `DIGEST_EMAIL_TO` / `SMTP_*` | Only if you want the daily email |
+
+Then bring over the Google Calendar OAuth files **once**:
+
+```bash
+# from the machine that already has them, or do the OAuth flow here:
+scp credentials.json token.json debmin@<vm>:~/galaxy_digital_gcal_sync/
+```
+
+If you don't have `token.json`, run `python verify_galaxy_creds.py` once
+interactively -- it will open the OAuth browser flow and write the token.
+
+## 4. Initial ingest (one-time)
+
+Populates SQLite before the systemd unit starts hammering the API:
+
+```bash
+python initial_ingest.py
+```
+
+You should see ~8k responses + ~20 recent hours + ~7k backfilled no-shows.
+
+## 5. Preview what would change on the production calendar
+
+```bash
+python preview_production_sync.py --days 30
+```
+
+Look at the INSERT / UPDATE / NO-OP / ORPHAN counts. Zero inserts means
+event ids match between the existing data and the new code -- no
+duplicates. Backup the production calendar first if you want a safety net:
+
+```bash
+# Google Calendar Settings -> "Export calendar" downloads everything as
+# an .ics zip. Save it somewhere safe.
+```
+
+## 6. Install the systemd units
+
+```bash
+sudo ./setup_galaxy_sync_service.sh
+```
+
+This writes two unit files and enables-and-starts both:
+
+| Unit | Purpose |
+|---|---|
+| `galaxy_sync.service` | runs `run_cal_update.py` -- the 2h full refresh + 60s scan loop |
+| `galaxy_web.service`  | runs `run_web.py` -- FastAPI on `127.0.0.1:8765` |
+
+Customize paths via env if your layout differs:
+
+```bash
+WORKING_DIR=/opt/galaxy USER=galaxy sudo -E ./setup_galaxy_sync_service.sh
+```
+
+## 7. Verify
+
+```bash
+sudo systemctl status galaxy_sync.service galaxy_web.service
+sudo journalctl -u galaxy_sync -f          # watch the sync log
+curl -u volunteer:$WEB_PASSWORD http://127.0.0.1:8765/ | head
+```
+
+After a few minutes you should see lines like:
+
+```
+Scan tick: pushed 1 shift updates
+update_responses: pushing 36 changed shift(s) to gcal
+```
+
+## Management cheatsheet
+
+```bash
+sudo systemctl restart galaxy_sync.service
+sudo systemctl stop    galaxy_sync.service galaxy_web.service
+sudo systemctl disable galaxy_sync.service galaxy_web.service   # remove from boot
+
+# logs
+sudo journalctl -u galaxy_sync.service -f
+sudo journalctl -u galaxy_web.service -f
+tail -F /home/debmin/galaxy_digital_gcal_sync/debug.log
+
+# one-off digest preview
+sudo -u debmin -E env GALAXY_DB_PATH=/home/debmin/galaxy_digital_gcal_sync/galaxy_sync.sqlite3 \
+  /home/debmin/galaxy_digital_gcal_sync/env/bin/python -m digest --dry-run
+```
+
+## Upgrades
+
+```bash
+cd /home/debmin/galaxy_digital_gcal_sync
+git pull
+source env/bin/activate
+pip install -r requirements.txt   # if requirements changed
+sudo systemctl restart galaxy_sync.service galaxy_web.service
+```
+
+## Exposing the web viewer beyond localhost
+
+By default `WEB_HOST=127.0.0.1` -- only reachable on the box. To make it
+LAN-accessible behind nginx with TLS:
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name volunteer-status.example.org;
+  ssl_certificate     /etc/letsencrypt/live/.../fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/.../privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:8765;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    # SSE: keep the stream open
+    proxy_buffering off;
+    proxy_read_timeout 1h;
+    proxy_http_version 1.1;
+  }
+}
+```
+
+The HTTP Basic auth from `WEB_PASSWORD` continues to gate access; nginx
+just adds TLS on the outside.

--- a/api.yaml
+++ b/api.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 x-stoplight:
   id: uo7lk8ian4ndt
 info:
-  version: 1.3.4
+  version: 1.9.2
   title: Get Connected Client API
   description: ''
 tags:
@@ -26,6 +26,8 @@ tags:
     description: Need related items
   - name: Qualification
     description: Qualification related items
+  - name: Question
+    description: Custom question related items
   - name: Response
     description: Response related items
   - name: Team
@@ -46,6 +48,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listEventsParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -54,6 +57,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listEventsParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -61,6 +65,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listEventsParamSinceCreated
             type: string
             format: date-time
             example: '2021-11-01 15:00'
@@ -69,6 +74,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listEventsParamSinceUpdated
             type: string
             format: date-time
             example: '2021-11-01 15:00'
@@ -82,6 +88,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listEventsResponse
                 type: object
                 properties:
                   data:
@@ -127,6 +134,7 @@ paths:
           description: ID of event
           required: true
           schema:
+            title: getEventParamId
             type: integer
       responses:
         '200':
@@ -134,6 +142,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getEventResponse
                 type: object
                 properties:
                   data:
@@ -156,6 +165,7 @@ paths:
           description: ID of Event
           required: true
           schema:
+            title: updateEventParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/eventRequest'
@@ -180,6 +190,7 @@ paths:
           description: ID of event
           required: true
           schema:
+            title: deleteEventParamId
             type: integer
       responses:
         '204':
@@ -206,12 +217,11 @@ paths:
           content:
             application/json:
               schema:
+                title: loginResponse
                 type: object
                 properties:
                   data:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/loginObject'
+                    $ref: '#/components/schemas/loginObject'
         '404':
           description: Not found
       security:
@@ -231,6 +241,7 @@ paths:
           content:
             application/json:
               schema:
+                title: authenticateResponse
                 type: object
                 properties:
                   data:
@@ -250,6 +261,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: agencyParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -258,6 +270,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: agencyParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -265,6 +278,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: agencyParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -273,6 +287,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: agencyParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -281,6 +296,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: agencyParamShowActive
             type: string
             enum:
               - 'Yes'
@@ -295,6 +311,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listAgenciesResponse
                 type: object
                 properties:
                   data:
@@ -339,6 +356,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: getAgencyParamId
             type: integer
       responses:
         '200':
@@ -346,6 +364,7 @@ paths:
           content:
             application/json:
               schema:
+                title: agencyGetResponse
                 type: object
                 properties:
                   data:
@@ -367,6 +386,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: updateAgencyParamId
             type: integer
       operationId: updateAgency
       requestBody:
@@ -392,6 +412,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: deleteAgencyParamId
             type: integer
       responses:
         '204':
@@ -415,6 +436,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyIndexCauseParamId
             type: integer
       responses:
         '200':
@@ -422,6 +444,7 @@ paths:
           content:
             application/json:
               schema:
+                title: agencyIndexCauseResponse
                 type: object
                 properties:
                   data:
@@ -447,12 +470,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyCausePostParamId
             type: integer
         - name: cause_id
           in: path
           description: ID of cause
           required: true
           schema:
+            title: agencyCausePostParamCauseId
             type: integer
       responses:
         '201':
@@ -475,12 +500,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyCauseDeleteParamId
             type: integer
         - name: cause_id
           in: path
           description: ID of cause
           required: true
           schema:
+            title: agencyCauseDeleteParamCauseId
             type: integer
       responses:
         '204':
@@ -504,6 +531,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyIndexClusterParamId
             type: integer
       responses:
         '200':
@@ -511,6 +539,7 @@ paths:
           content:
             application/json:
               schema:
+                title: agencyIndexClusterResponse
                 type: object
                 properties:
                   data:
@@ -536,12 +565,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyClusterPostParamId
             type: integer
         - name: cluster_id
           in: path
           description: ID of cluster
           required: true
           schema:
+            title: agencyClusterPostParamClusterId
             type: integer
       responses:
         '201':
@@ -564,12 +595,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyClusterDeleteParamId
             type: integer
         - name: cluster_id
           in: path
           description: ID of cluster
           required: true
           schema:
+            title: agencyClusterDeleteParamClusterId
             type: integer
       responses:
         '204':
@@ -593,6 +626,7 @@ paths:
           description: ID of
           required: true
           schema:
+            title: agencyIndexManagerParamId
             type: integer
       responses:
         '200':
@@ -600,6 +634,7 @@ paths:
           content:
             application/json:
               schema:
+                title: agencyIndexManagerResponse
                 type: object
                 properties:
                   data:
@@ -625,12 +660,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: createAgencyManagerParamId
             type: integer
         - name: user_id
           in: path
           description: ID of user being added as a manager
           required: true
           schema:
+            title: createAgencyManagerParamUserId
             type: integer
       responses:
         '201':
@@ -653,12 +690,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: deleteAgencyManagerParamId
             type: integer
         - name: user_id
           in: path
           description: ID of user being deleted as a manager
           required: true
           schema:
+            title: deleteAgencyManagerParamUserId
             type: integer
       responses:
         '204':
@@ -682,6 +721,7 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyIndexTagParamId
             type: integer
       responses:
         '200':
@@ -689,6 +729,7 @@ paths:
           content:
             application/json:
               schema:
+                title: agencyIndexTagResponse
                 type: object
                 properties:
                   data:
@@ -713,11 +754,13 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: createAgencyTagParamId
             type: integer
       requestBody:
         content:
           application/json:
             schema:
+              title: createAgencyTagResponse
               type: object
               required:
                 - tags
@@ -751,12 +794,14 @@ paths:
           description: ID of agency
           required: true
           schema:
+            title: agencyTagDeleteParamId
             type: integer
         - name: tag_id
           in: path
           description: ID of tag
           required: true
           schema:
+            title: agencyTagDeleteParamTagId
             type: integer
       responses:
         '204':
@@ -776,6 +821,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listBenchmarksParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -784,6 +830,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listBenchmarksParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -791,6 +838,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listBenchmarksParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -799,6 +847,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listBenchmarksParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -807,6 +856,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listBenchmarksParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -821,6 +871,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listBenchmarksResponse
                 type: object
                 properties:
                   data:
@@ -852,6 +903,7 @@ paths:
           description: Failed Validation
       security:
         - Bearer: []
+
   '/benchmarks/{id}':
     get:
       tags:
@@ -865,6 +917,7 @@ paths:
           description: ID of
           required: true
           schema:
+            title: getBenchmarkParamId
             type: integer
       responses:
         '200':
@@ -872,6 +925,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getBenchmarkResponse
                 type: object
                 properties:
                   data:
@@ -894,6 +948,7 @@ paths:
           description: ID of benchmark
           required: true
           schema:
+            title: updateBenchmarkParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/benchmarkRequest'
@@ -918,6 +973,7 @@ paths:
           description: ID of benchmark
           required: true
           schema:
+            title: deleteBenchmarkParamId
             type: integer
       responses:
         '204':
@@ -941,6 +997,7 @@ paths:
           description: ID of benchmark
           required: true
           schema:
+            title: listBenchmarkUsersParamId
             type: integer
       responses:
         '200':
@@ -948,6 +1005,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listBenchmarkUsersResponse
                 type: object
                 properties:
                   data:
@@ -973,6 +1031,7 @@ paths:
           content:
             application/json:
               schema:
+                title: causesIndexResponse
                 type: object
                 properties:
                   data:
@@ -998,6 +1057,7 @@ paths:
           content:
             application/json:
               schema:
+                title: clustersIndexResponse
                 type: object
                 properties:
                   data:
@@ -1024,6 +1084,7 @@ paths:
           content:
             application/json:
               schema:
+                title: createClusterResponse
                 type: object
                 properties:
                   data:
@@ -1049,6 +1110,7 @@ paths:
           description: ID of cluster
           required: true
           schema:
+            title: deleteClustersParamId
             type: integer
       responses:
         '204':
@@ -1073,6 +1135,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listHoursParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -1081,6 +1144,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listHoursParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -1088,6 +1152,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listHoursParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1096,6 +1161,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listHoursParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1104,6 +1170,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listHoursParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -1115,6 +1182,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listHoursParamResponse
                 type: object
                 properties:
                   data:
@@ -1161,6 +1229,7 @@ paths:
           description: ID of hour
           required: true
           schema:
+            title: getHourParamId
             type: integer
       responses:
         '200':
@@ -1168,6 +1237,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getHourResponse
                 type: object
                 properties:
                   data:
@@ -1190,6 +1260,7 @@ paths:
           description: ID of Hour
           required: true
           schema:
+            title: updateHourParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/hourRequest'
@@ -1214,6 +1285,7 @@ paths:
           description: ID of hour
           required: true
           schema:
+            title: deleteHourParamId
             type: integer
       responses:
         '204':
@@ -1237,6 +1309,7 @@ paths:
           content:
             application/json:
               schema:
+                title: impactsIndexResponse
                 type: object
                 properties:
                   data:
@@ -1262,6 +1335,7 @@ paths:
           content:
             application/json:
               schema:
+                title: interestsIndexResponse
                 type: object
                 properties:
                   data:
@@ -1286,6 +1360,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listNeedsParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -1295,6 +1370,7 @@ paths:
           description: Id of agency that created need
           required: false
           schema:
+            title: listNeedsParamAgencyId
             type: array
             items:
               type: integer
@@ -1303,12 +1379,14 @@ paths:
           description: Name of need you are search.
           required: false
           schema:
+            title: listNeedsParamNeedTitle
             type: string
         - name: need_status
           in: query
           description: Status of needs you would like to find.
           required: false
           schema:
+            title: listNeedsParamNeedStatus
             type: string
             enum:
               - active
@@ -1318,6 +1396,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listNeedsParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -1325,6 +1404,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listNeedsParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1333,6 +1413,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listNeedsParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1341,6 +1422,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listNeedsParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -1352,6 +1434,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listNeedsResponse
                 type: object
                 properties:
                   data:
@@ -1396,6 +1479,7 @@ paths:
           description: ID of Need
           required: true
           schema:
+            title: getNeedParamId
             type: integer
       responses:
         '200':
@@ -1403,6 +1487,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getNeedResponse
                 type: object
                 properties:
                   data:
@@ -1425,6 +1510,7 @@ paths:
           description: ID of Need
           required: true
           schema:
+            title: updateNeedParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/needRequest'
@@ -1449,6 +1535,7 @@ paths:
           description: ID of Need
           required: true
           schema:
+            title: deleteNeedParamId
             type: integer
       responses:
         '204':
@@ -1472,6 +1559,7 @@ paths:
           description: ID of Need
           required: true
           schema:
+            title: listNeedResponsesParamId
             type: integer
       responses:
         '200':
@@ -1479,6 +1567,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listNeedResponsesResponse
                 type: object
                 properties:
                   data:
@@ -1491,6 +1580,97 @@ paths:
           description: No results
       security:
         - Bearer: []
+
+  '/needs/{id}/shifts':
+    post:
+      tags:
+        - Need
+      summary: Create shifts for an existing need
+      description: Create shifts for an existing need
+      operationId: needAddShifts
+      parameters:
+        - name: id
+          in: path
+          description: ID of need
+          required: true
+          schema:
+            title: needAddInterestParamId
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: needAddShiftsRequestSchema
+              type: object
+              required:
+                - shifts
+              properties:
+                shifts:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - start
+                      - slots
+                      - duration
+                    properties:
+                      start:
+                        type: string
+                        format: datetime
+                        example: 2024-02-28 12:00
+                      slots:
+                        type: string
+                        format: integer
+                        description: The response limit
+                        example: 15
+                      duration:
+                        type: string
+                        format: integer
+                        description: The number of minutes in the shift
+                        example: 120
+
+      responses:
+        '201':
+          description: Created
+        '401':
+          description: Unauthorized
+        '404':
+          description: No results
+      security:
+        - Bearer: []
+
+  '/needs/{id}/shifts/{shift_id}':
+    delete:
+      tags:
+        - Need
+      summary: Remove shift from a need
+      description: Remove shift from a need
+      operationId: needRemoveShifts
+      parameters:
+        - name: id
+          in: path
+          description: ID of need
+          required: true
+          schema:
+            title: needAddShiftParamId
+            type: integer
+        - name: shift_id
+          in: path
+          description: ID of shift to be removed
+          required: true
+          schema:
+            title: needAddShiftParamIdShiftId
+            type: integer
+      responses:
+        '204':
+          description: Successful operation
+        '401':
+          description: Unauthorized
+        '404':
+          description: No results
+      security:
+        - Bearer: []
+
   '/needs/{id}/interests/{interest_id}':
     post:
       tags:
@@ -1504,12 +1684,14 @@ paths:
           description: ID of need
           required: true
           schema:
+            title: needAddInterestParamId
             type: integer
         - name: interest_id
           in: path
           description: ID of interest
           required: true
           schema:
+            title: needAddInterestParamInterestId
             type: integer
       responses:
         '201':
@@ -1532,12 +1714,14 @@ paths:
           description: ID of need
           required: true
           schema:
+            title: needDeleteInterestParamId
             type: integer
         - name: interest_id
           in: path
           description: ID of interest
           required: true
           schema:
+            title: needDeleteInterestParamInterestId
             type: integer
       responses:
         '204':
@@ -1561,12 +1745,14 @@ paths:
           description: ID of need
           required: true
           schema:
+            title: needAddQualificationParamId
             type: integer
         - name: qualification_id
           in: path
           description: ID of qualification
           required: true
           schema:
+            title: needAddQualificationParamQualificationId
             type: integer
       responses:
         '201':
@@ -1591,12 +1777,14 @@ paths:
           description: ID of need
           required: true
           schema:
+            title: needDeleteQualificationParamId
             type: integer
         - name: qualification_id
           in: path
           description: ID of qualification
           required: true
           schema:
+            title: needDeleteQualificationParamQualificationId
             type: integer
       responses:
         '204':
@@ -1620,6 +1808,7 @@ paths:
           description: ID of Need
           required: true
           schema:
+            title: listNeedQuestionsParamId
             type: integer
       responses:
         '200':
@@ -1627,6 +1816,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listNeedQuestionsResponse
                 type: object
                 properties:
                   data:
@@ -1648,6 +1838,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listQualificationsParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -1656,6 +1847,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listQualificationsParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -1663,6 +1855,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listQualificationsParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1671,6 +1864,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listQualificationsParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1679,6 +1873,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listQualificationsParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -1693,6 +1888,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listQualificationsResponse
                 type: object
                 properties:
                   data:
@@ -1737,6 +1933,7 @@ paths:
           description: ID of qualification
           required: true
           schema:
+            title: getQualificationParamId
             type: integer
       responses:
         '200':
@@ -1744,6 +1941,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getQualificationResponse
                 type: object
                 properties:
                   data:
@@ -1766,6 +1964,7 @@ paths:
           description: ID of qualification
           required: true
           schema:
+            title: updateQualificationParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/qualificationRequest'
@@ -1790,6 +1989,7 @@ paths:
           description: ID of qualification
           required: true
           schema:
+            title: deleteQualificationParamId
             type: integer
       responses:
         '204':
@@ -1813,6 +2013,7 @@ paths:
           description: ID of
           required: true
           schema:
+            title: listQualificationUsersParamId
             type: integer
       responses:
         '200':
@@ -1820,6 +2021,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listQualificationUsersResponse
                 type: object
                 properties:
                   data:
@@ -1832,6 +2034,36 @@ paths:
           description: No results
       security:
         - Bearer: []
+
+  /questions/registration:
+    get:
+      tags:
+        - Question
+      summary: List custom registration questions
+      description: List custom registration questions
+      operationId: listRegistrationQuestions
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                title: listRegistrationQuestionsResponse
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/questionObject'
+        '401':
+          description: Unauthorized
+        '404':
+          description: No results
+        '422':
+          description: Failed Validation
+      security:
+        - Bearer: []
+
   /responses:
     get:
       tags:
@@ -1844,6 +2076,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listResponsesParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -1852,6 +2085,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listResponsesParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -1859,6 +2093,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listResponsesParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1867,6 +2102,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listResponsesParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -1875,6 +2111,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listResponsesParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -1886,6 +2123,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listResponsesResponse
                 type: object
                 properties:
                   data:
@@ -1930,6 +2168,7 @@ paths:
           description: ID of
           required: true
           schema:
+            title: getResponseParamId
             type: integer
       responses:
         '200':
@@ -1937,6 +2176,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getResponseResponse
                 type: object
                 properties:
                   data:
@@ -1959,6 +2199,7 @@ paths:
           description: ID of Response
           required: true
           schema:
+            title: updateResponseParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/responseRequest'
@@ -1983,6 +2224,7 @@ paths:
           description: ID of response
           required: true
           schema:
+            title: deleteResponseParamId
             type: integer
       responses:
         '204':
@@ -2002,6 +2244,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listTeamsParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -2010,6 +2253,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listTeamsParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -2017,6 +2261,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listTeamsParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -2025,6 +2270,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listTeamsParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -2033,6 +2279,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listTeamsParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -2047,6 +2294,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listTeamsResponse
                 type: object
                 properties:
                   data:
@@ -2091,6 +2339,7 @@ paths:
           description: ID of team
           required: true
           schema:
+            title: getTeamParamId
             type: integer
       responses:
         '200':
@@ -2098,6 +2347,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getTeamResponse
                 type: object
                 properties:
                   data:
@@ -2120,6 +2370,7 @@ paths:
           description: ID of team
           required: true
           schema:
+            title: deleteTeamParamId
             type: integer
       responses:
         '204':
@@ -2143,18 +2394,21 @@ paths:
           description: ID of team
           required: true
           schema:
+            title: teamMemberAttachParamId
             type: integer
         - name: member
           in: path
           description: ID of user being attached to team
           required: true
           schema:
+            title: teamMemberAttachParamMember
             type: integer
       requestBody:
         required: true
         content:
           application/json:
             schema:
+              title: teamMemberAttachRequest
               type: object
               properties:
                 sch_id:
@@ -2183,12 +2437,14 @@ paths:
           description: ID of team
           required: true
           schema:
+            title: teamMemberDetachParamId
             type: integer
         - name: member
           in: path
           description: ID of user being detached from team
           required: true
           schema:
+            title: teamMemberDetachParamMember
             type: integer
       responses:
         '204':
@@ -2211,18 +2467,29 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listUsersParamPerPage
             type: integer
             minimum: 1
             maximum: 150
           description: Define how many results are returned per page
+        - in: query
+          name: page
+          required: false
+          schema:
+            title: listUsersParamPage
+            type: integer
+            minimum: 1
+          description: page number
         - name: user_status
           in: query
           description: Status values that need to be considered for filter
           required: false
           schema:
+            title: listUsersParamUserArrayStatus
             type: array
             items:
               type: string
+              title: listUsersParamUserStatus
               enum:
                 - active
                 - pending
@@ -2234,18 +2501,21 @@ paths:
           description: User first name
           required: false
           schema:
+            title: listUsersParamUserFname
             type: string
         - name: user_lname
           in: query
           description: User last name
           required: false
           schema:
+            title: listUsersParamUserLname
             type: string
         - name: user_email
           in: query
           description: User email address
           required: false
           schema:
+            title: listUsersParamUserEmail
             type: string
             format: email
         - name: user_fname_like
@@ -2253,24 +2523,28 @@ paths:
           description: Filter by partial user first name
           required: false
           schema:
+            title: listUsersParamUserFnameLike
             type: string
         - name: user_lname_like
           in: query
           description: Filter by partial user last name
           required: false
           schema:
+            title: listUsersParamUserLnameLike
             type: string
         - name: user_email_like
           in: query
           description: Filter by partial user email address
           required: false
           schema:
+            title: listUsersParamUserEmailLike
             type: string
             format: email
         - in: query
           name: since_id
           required: false
           schema:
+            title: listUsersParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -2278,6 +2552,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listUsersParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -2286,6 +2561,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listUsersParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -2294,6 +2570,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listUsersParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -2305,12 +2582,40 @@ paths:
           content:
             application/json:
               schema:
+                title: listUsersParamResponse
                 type: object
                 properties:
                   data:
                     type: array
                     items:
                       $ref: '#/components/schemas/userObject'
+                  links:
+                    type: object
+                    properties:
+                      first:
+                        type: string
+                      last:
+                        nullable: true
+                        type: string
+                      prev:
+                        nullable: true
+                        type: string
+                      next:
+                        nullable: true
+                        type: string
+                  meta:
+                    type: object
+                    properties:
+                      current_page:
+                        type: integer
+                      from:
+                        type: integer
+                      path:
+                        type: string
+                      per_page:
+                        type: integer
+                      to:
+                        type: integer
         '401':
           description: Unauthorized
         '404':
@@ -2347,6 +2652,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: getUserParamId
             type: integer
       responses:
         '200':
@@ -2354,6 +2660,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getUserResponse
                 type: object
                 properties:
                   data:
@@ -2378,6 +2685,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: putUserParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/userRequest'
@@ -2404,6 +2712,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserParamId
             type: integer
       responses:
         '204':
@@ -2427,6 +2736,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserAgenciesParamId
             type: integer
       responses:
         '200':
@@ -2434,6 +2744,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserAgenciesResponse
                 type: object
                 properties:
                   data:
@@ -2459,12 +2770,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: createUserAgencyFanParamId
             type: integer
         - name: agency_id
           in: path
           description: ID of agency
           required: true
           schema:
+            title: createUserAgencyFanParamAgencyId
             type: integer
       responses:
         '200':
@@ -2489,12 +2802,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserAgencyFanParamId
             type: integer
         - name: agency_id
           in: path
           description: ID of agency
           required: true
           schema:
+            title: deleteUserAgencyFanParamAgencyId
             type: integer
       responses:
         '204':
@@ -2518,6 +2833,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserBenchmarksParamId
             type: integer
       responses:
         '200':
@@ -2525,6 +2841,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserBenchmarksResponse
                 type: object
                 properties:
                   data:
@@ -2548,12 +2865,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserBenchmarkParamId
             type: integer
         - name: benchmark_id
           in: path
           description: ID of benchmark
           required: true
           schema:
+            title: deleteUserBenchmarkParamBenchmarkId
             type: integer
       responses:
         '204':
@@ -2577,6 +2896,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserCausesParamId
             type: integer
       responses:
         '200':
@@ -2584,6 +2904,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserCausesResponse
                 type: object
                 properties:
                   data:
@@ -2609,17 +2930,20 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: createUserCauseParamId
             type: integer
         - name: cause_id
           in: path
           description: ID of user / cause relationship
           required: true
           schema:
+            title: createUserCauseParamCauseId
             type: integer
       requestBody:
         content:
           application/json:
             schema:
+              title: createUserCauseRequest
               type: object
               required:
                 - name
@@ -2647,12 +2971,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserCauseParamId
             type: integer
         - name: cause_id
           in: path
           description: ID of user / cause relationship
           required: true
           schema:
+            title: deleteUserCauseParamCauseId
             type: integer
       responses:
         '204':
@@ -2676,13 +3002,25 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserExtrasParamId
             type: integer
+        - in: query
+          name: subset
+          required: false
+          schema:
+            title: listUserExtrasParamSubset
+            type: string
+            enum:
+              - 'regExtra'
+              - 'profile'
+          description: Define the subset of results you want back. The default is regExtra.
       responses:
         '200':
           description: Successful operation
           content:
             application/json:
               schema:
+                title: listUserExtrasResponse
                 type: object
                 properties:
                   data:
@@ -2707,11 +3045,23 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: createUserExtraParamId
             type: integer
+        - name: subset
+          in: query
+          description: Desired subset to store data under. If empty, the default is regExtra.
+          required: false
+          schema:
+            title: createUserExtraParamSubset
+            type: string
+            enum:
+              - regExtra
+              - profile
       requestBody:
         content:
           application/json:
             schema:
+              title: createUserExtraRequest
               type: object
               properties:
                 extras:
@@ -2725,7 +3075,7 @@ paths:
                         type: string
                         example: Spanish
       responses:
-        '200':
+        '201':
           description: Successful operation
         '401':
           description: Unauthorized
@@ -2746,6 +3096,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserhoursParamId
             type: integer
       responses:
         '200':
@@ -2753,6 +3104,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserhoursResponse
                 type: object
                 properties:
                   data:
@@ -2778,6 +3130,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserInterestsParamId
             type: integer
       responses:
         '200':
@@ -2785,6 +3138,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserInterestsResponse
                 type: object
                 properties:
                   data:
@@ -2810,12 +3164,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: addUserInterestParamId
             type: integer
         - name: interest_id
           in: path
           description: ID interest
           required: true
           schema:
+            title: addUserInterestParamInterestId
             type: integer
       responses:
         '200':
@@ -2838,12 +3194,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserInterestParamId
             type: integer
         - name: interest_id
           in: path
           description: ID of user / interests relationship
           required: true
           schema:
+            title: deleteUserInterestParamInterestId
             type: integer
       responses:
         '204':
@@ -2868,6 +3226,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: getUserWelcomeEmailParamId
             type: integer
       responses:
         '201':
@@ -2892,6 +3251,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: getUserOneclickParamId
             type: integer
       responses:
         '200':
@@ -2899,6 +3259,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getUserOneclickResponse
                 type: object
                 properties:
                   data:
@@ -2922,10 +3283,19 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: getUserOptoutParamId
             type: integer
       responses:
         '200':
           description: User has opted out
+          content:
+            application/json:
+              schema:
+                title: getUserOptoutResponse
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/userOptoutsObject'
         '401':
           description: Unauthorized
         '404':
@@ -2944,7 +3314,36 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: createUserOptoutParamId
             type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: createUserOptoutRequest
+              type: object
+              required:
+                - optout_areas
+              properties:
+                optout_areas:
+                  description: Submitted opt-out areas will supersede previously saved optouts. Submitting "all" will opt the user out of all messaging.
+                  type: array
+                  example:
+                    - reminders_and_confirmations
+                    - news_and_recommendations
+                    - surveys_and_thank_yous
+                    - schedule_updates
+                    - account_management
+                    - site_manager_activity
+                    - site_manager_tasks
+                    - site_manager_updates
+                    - agency_manager_activity
+                    - agency_manager_tasks
+                    - agency_manager_updates
+                    - blast
+                    - all
+                  items:
+                    type: string
       responses:
         '201':
           description: Successful operation
@@ -2966,7 +3365,36 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserOptoutParamId
             type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: deleteUserOptoutRequest
+              type: object
+              required:
+                - optout_areas
+              properties:
+                optout_areas:
+                  description: Submit only the areas you wish to remove from the user's opt-out list.
+                  type: array
+                  example:
+                    - reminders_and_confirmations
+                    - news_and_recommendations
+                    - surveys_and_thank_yous
+                    - schedule_updates
+                    - account_management
+                    - site_manager_activity
+                    - site_manager_tasks
+                    - site_manager_updates
+                    - agency_manager_activity
+                    - agency_manager_tasks
+                    - agency_manager_updates
+                    - blast
+                    - all
+                  items:
+                    type: string
       responses:
         '204':
           description: Successful operation
@@ -2989,6 +3417,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserQualificationsParamId
             type: integer
       responses:
         '200':
@@ -2996,6 +3425,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserQualificationsResponse
                 type: object
                 properties:
                   data:
@@ -3006,6 +3436,88 @@ paths:
           description: Unauthorized
       security:
         - Bearer: []
+
+  '/users/{id}/registrationQuestions':
+    get:
+      tags:
+        - User
+      summary: Get list of user responses to registration questions
+      description: Get list of user responses to registration questions
+      operationId: listUserRegistrationQuestionAnswers
+      parameters:
+        - name: id
+          in: path
+          description: ID of user
+          required: true
+          schema:
+            title: listRegistrationQuestionAnswersParamId
+            type: integer
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                title: listRegistrationQuestionAnswersResponse
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/RegistrationResponseAnswerObject'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not found
+      security:
+        - Bearer: []
+    post:
+      tags:
+        - User
+      summary: Store answers to custom registration questions
+      description: Store answers to custom registration questions
+      operationId: createRegistrationQuestionAnswers
+      parameters:
+        - name: id
+          in: path
+          description: ID of user
+          required: true
+          schema:
+            title: createRegistrationQuestionAnswersParamId
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: createRegistrationQuestionAnswersRequest
+              type: object
+              required:
+                - answers
+              properties:
+                answers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      question_id:
+                        type: string
+                        format: number
+                        example: 431255
+                      answer:
+                        type: array
+                        items:
+                          type: string
+                          example: First answer
+      responses:
+        '201':
+          description: Created
+        '401':
+          description: Unauthorized
+        '404':
+          description: No results
+      security:
+        - Bearer: []
+
   '/users/{id}/responses':
     get:
       tags:
@@ -3019,6 +3531,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserResponsesParamId
             type: integer
       responses:
         '200':
@@ -3026,6 +3539,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserResponsesResponse
                 type: object
                 properties:
                   data:
@@ -3051,6 +3565,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserTracksParamId
             type: integer
       responses:
         '200':
@@ -3058,6 +3573,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserTracksResponse
                 type: object
                 properties:
                   data:
@@ -3083,6 +3599,7 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: listUserTagsParamId
             type: integer
       responses:
         '200':
@@ -3090,6 +3607,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listUserTagsResponse
                 type: object
                 properties:
                   data:
@@ -3105,8 +3623,8 @@ paths:
     post:
       tags:
         - User
-      summary: List tags assigned to a user
-      description: List tags assigned to a user
+      summary: Add tags to a user
+      description: Add tags to a user
       operationId: createUserTag
       parameters:
         - name: id
@@ -3114,11 +3632,13 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: createUserTagParamId
             type: integer
       requestBody:
         content:
           application/json:
             schema:
+              title: createUserTagRequest
               type: object
               required:
                 - tags
@@ -3131,8 +3651,8 @@ paths:
                   items:
                     type: string
       responses:
-        '200':
-          description: Successful operation
+        '201':
+          description: Created
         '401':
           description: Unauthorized
         '404':
@@ -3152,12 +3672,14 @@ paths:
           description: ID of user
           required: true
           schema:
+            title: deleteUserTagParamId
             type: integer
         - name: tag_id
           in: path
           description: ID of tag
           required: true
           schema:
+            title: deleteUserTagParamTagId
             type: integer
       responses:
         '204':
@@ -3177,6 +3699,7 @@ paths:
           name: per_page
           required: false
           schema:
+            title: listGroupsParamPerPage
             type: integer
             minimum: 1
             maximum: 150
@@ -3185,6 +3708,7 @@ paths:
           name: since_id
           required: false
           schema:
+            title: listGroupsParamSinceId
             type: integer
             minimum: 1
           description: Filtering items that have been added since that ID
@@ -3192,6 +3716,7 @@ paths:
           name: since_created
           required: false
           schema:
+            title: listGroupsParamSinceCreated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -3200,6 +3725,7 @@ paths:
           name: since_updated
           required: false
           schema:
+            title: listGroupsParamSinceUpdated
             type: string
             format: datetime
             example: '2021-11-01 15:00'
@@ -3208,6 +3734,7 @@ paths:
           name: show_inactive
           required: false
           schema:
+            title: listGroupsParamShowInactive
             type: string
             enum:
               - 'Yes'
@@ -3222,6 +3749,7 @@ paths:
           content:
             application/json:
               schema:
+                title: listGroupsResponse
                 type: object
                 properties:
                   data:
@@ -3266,6 +3794,7 @@ paths:
           description: ID of
           required: true
           schema:
+            title: getGroupParamId
             type: integer
       responses:
         '200':
@@ -3273,6 +3802,7 @@ paths:
           content:
             application/json:
               schema:
+                title: getGroupResponse
                 type: object
                 properties:
                   data:
@@ -3295,6 +3825,7 @@ paths:
           description: ID of user group
           required: true
           schema:
+            title: updateGroupParamId
             type: integer
       requestBody:
         $ref: '#/components/requestBodies/groupRequest'
@@ -3319,6 +3850,7 @@ paths:
           description: ID of user group
           required: true
           schema:
+            title: deleteGroupParamId
             type: integer
       responses:
         '204':
@@ -3342,12 +3874,14 @@ paths:
           description: ID of group
           required: true
           schema:
+            title: postGroupNeedParamId
             type: integer
         - name: need_id
           in: path
           description: ID of need being added to group
           required: true
           schema:
+            title: postGroupNeedParamNeedId
             type: integer
       responses:
         '201':
@@ -3368,12 +3902,14 @@ paths:
           description: ID of
           required: true
           schema:
+            title: deleteGroupNeedParamId
             type: integer
         - name: need_id
           in: path
           description: ID of need to remove
           required: true
           schema:
+            title: deleteGroupNeedParamNeedId
             type: integer
       responses:
         '204':
@@ -3397,12 +3933,14 @@ paths:
           description: ID of
           required: true
           schema:
+            title: postGroupUserParamId
             type: integer
         - name: user_id
           in: path
           description: ID of user to remove
           required: true
           schema:
+            title: postGroupUserParamUserId
             type: integer
       responses:
         '201':
@@ -3423,12 +3961,14 @@ paths:
           description: ID of
           required: true
           schema:
+            title: deleteGroupUserParamId
             type: integer
         - name: user_id
           in: path
           description: ID of user to remove
           required: true
           schema:
+            title: deleteGroupUserParamUserId
             type: integer
       responses:
         '204':
@@ -3520,6 +4060,7 @@ components:
             $ref: '#/components/schemas/authenticateRequestSchema'
   schemas:
     groupObject:
+      title: groupObjectSchema
       type: object
       properties:
         id:
@@ -3613,6 +4154,7 @@ components:
           items:
             $ref: '#/components/schemas/questionObject'
     teamObject:
+      title: teamObjectSchema
       type: object
       properties:
         id:
@@ -3641,15 +4183,19 @@ components:
           items:
             $ref: '#/components/schemas/teamMembersObject'
     agencyMiniObject:
+      title: agencyMiniObjectSchema
       type: object
       properties:
         id:
-          type: integer
+          type: string
+          format: number
         domain_id:
-          type: integer
+          type: string
+          format: number
         agency_name:
           type: string
     initiativeMiniObject:
+      title: initiativeMiniObjectSchema
       type: object
       properties:
         id:
@@ -3661,6 +4207,7 @@ components:
         init_title:
           type: string
     groupMiniObject:
+      title: groupMiniObjectSchema
       type: object
       properties:
         id:
@@ -3672,6 +4219,7 @@ components:
         group_title:
           type: string
     needMiniObject:
+      title: needMiniObjectSchema
       type: object
       properties:
         id:
@@ -3682,13 +4230,33 @@ components:
           format: number
         need_title:
           type: string
-    ResponseAnswerObject:
+    RegistrationResponseAnswerObject:
+      title: RegistrationResponseAnswerObjectSchema
       type: object
       properties:
         type:
           type: string
         key:
           type: string
+          format: number
+        area:
+          type: string
+        question_id:
+          type: string
+          format: number
+        question:
+          type: string
+        answer:
+          type: string
+    ResponseAnswerObject:
+      title: ResponseAnswerObjectSchema
+      type: object
+      properties:
+        type:
+          type: string
+        key:
+          type: string
+          format: number
         area:
           type: string
         question:
@@ -3696,6 +4264,7 @@ components:
         answer:
           type: string
     trackMiniObject:
+      title: trackMiniObjectSchema
       type: object
       properties:
         id:
@@ -3710,6 +4279,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     teamMiniObject:
+      title: teamMiniObjectSchema
       type: object
       properties:
         id:
@@ -3718,9 +4288,10 @@ components:
         domain_id:
           type: string
           format: number
-        name:
+        team_name:
           type: string
     GroupUserMiniObject:
+      title: GroupUserMiniObjectSchema
       type: object
       properties:
         id:
@@ -3741,6 +4312,7 @@ components:
             - 'Yes'
             - 'No'
     userMiniObject:
+      title: userMiniObjectSchema
       type: object
       properties:
         id:
@@ -3756,6 +4328,7 @@ components:
         user_email:
           type: string
     teamMembersObject:
+      title: teamMembersObjectSchema
       type: object
       properties:
         id:
@@ -3775,7 +4348,26 @@ components:
           enum:
             - 'Yes'
             - 'No'
+    userOptoutsObject:
+      title: userOptoutsObjectSchema
+      type: object
+      properties:
+        id:
+          type: string
+          format: number
+        email:
+          type: string
+          format: email
+        optout_areas:
+          type: array
+          items:
+            type: string
+            example: "surveys_and_thank_yous"
+        date_added:
+          type: string
+          format: datetime
     userQualificationsObject:
+      title: userQualificationsObjectSchema
       type: object
       properties:
         id:
@@ -3802,6 +4394,7 @@ components:
           type: string
           format: date
     qualificationUsersObject:
+      title: qualificationUsersObjectSchema
       type: object
       properties:
         id:
@@ -3829,6 +4422,7 @@ components:
           type: string
           format: date
     categoryObject:
+      title: categoryObjectSchema
       type: object
       properties:
         id:
@@ -3837,13 +4431,16 @@ components:
         name:
           type: string
     extraObject:
+      title: extraObjectSchema
       type: object
       properties:
         key:
           type: string
         value:
+          nullable: true
           type: string
     qualificationObject:
+      title: qualificationObjectSchema
       type: object
       properties:
         id:
@@ -3910,6 +4507,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     needObject:
+      title: needObjectSchema
       type: object
       properties:
         id:
@@ -4012,6 +4610,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     agencyObject:
+      title: agencyObjectSchema
       type: object
       properties:
         id:
@@ -4109,6 +4708,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     shiftRequestSchema:
+      title: shiftRequestSchema
       type: object
       properties:
         slots:
@@ -4127,6 +4727,7 @@ components:
           example: "120"
           description: Duration in minutes
     shiftObject:
+      title: shiftObjectSchema
       type: object
       properties:
         id:
@@ -4146,6 +4747,7 @@ components:
           type: string
           format: number
     userOneclickObject:
+      title: userOneclickObjectSchema
       type: object
       properties:
         link:
@@ -4160,6 +4762,7 @@ components:
           format: datetime
           example: '2022-01-14 14:10:00'
     userObject:
+      title: userObjectSchema
       type: object
       properties:
         id:
@@ -4168,6 +4771,8 @@ components:
         domain_id:
           type: string
           format: number
+        domain_sitename:
+          type: string
         user_reference_id:
           type: string
         user_fname:
@@ -4199,6 +4804,7 @@ components:
         user_country:
           type: string
         user_age_range:
+          nullable: true
           type: string
           enum:
             - 13-18
@@ -4216,6 +4822,7 @@ components:
             - 'No'
         user_birthday:
           type: string
+          nullable: true
           format: date
         user_company:
           type: string
@@ -4225,6 +4832,7 @@ components:
           type: string
         user_ethnicity:
           type: string
+          nullable: true
           enum:
             - American Indian and Alaska Native
             - Asian
@@ -4235,6 +4843,7 @@ components:
             - White
         user_gender:
           type: string
+          nullable: true
           enum:
             - Male
             - Female
@@ -4242,6 +4851,7 @@ components:
             - Other
         user_grad_semester:
           type: string
+          nullable: true
           enum:
             - spring
             - summer
@@ -4257,6 +4867,7 @@ components:
         user_status:
           type: string
           example: active
+          nullable: true
           enum:
             - active
             - pending
@@ -4271,6 +4882,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     questionObject:
+      title: questionObjectSchema
       type: object
       properties:
         id:
@@ -4285,6 +4897,10 @@ components:
             - radio
             - checkbox
             - select
+        q_label:
+          type: string
+          description: The question being asked
+          example: What is your favorite color?
         q_options:
           type: array
           example:
@@ -4319,6 +4935,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     hourObject:
+      title: hourObjectSchema
       type: object
       properties:
         id:
@@ -4355,6 +4972,8 @@ components:
           type: string
         hour_relationship:
           type: string
+        hour_parent:
+          type: string
         hour_source:
           type: string
         hour_status:
@@ -4380,6 +4999,7 @@ components:
           format: date-time
           example: '2021-01-01 12:00:00'
     userResponseObject:
+      title: userResponseObjectSchema
       type: object
       properties:
         id:
@@ -4406,6 +5026,7 @@ components:
           type: string
           format: date-time
     responseObject:
+      title: responseObjectSchema
       type: object
       properties:
         id:
@@ -4452,6 +5073,7 @@ components:
           items:
             $ref: '#/components/schemas/ResponseAnswerObject'
     tagObject:
+      title: tagObjectSchema
       type: object
       properties:
         id:
@@ -4460,6 +5082,7 @@ components:
         name:
           type: string
     interestObject:
+      title: interestObjectSchema
       type: object
       properties:
         id:
@@ -4469,6 +5092,7 @@ components:
         name:
           type: string
     impactObject:
+      title: impactObjectSchema
       type: object
       properties:
         id:
@@ -4478,6 +5102,7 @@ components:
         impact_name:
           type: string
     causeObject:
+      title: causeObjectSchema
       type: object
       properties:
         id:
@@ -4487,6 +5112,7 @@ components:
         name:
           type: string
     eventObject:
+      title: eventObjectSchema
       type: object
       properties:
         id:
@@ -4555,6 +5181,7 @@ components:
           format: date-
           example: '2021-01-01 12:00:00'
     loginObject:
+      title: loginObjectSchema
       type: object
       properties:
         user:
@@ -4580,6 +5207,7 @@ components:
           type: string
           format: date-time
     clusterObject:
+      title: clusterObjectSchema
       type: object
       properties:
         id:
@@ -4589,6 +5217,7 @@ components:
         name:
           type: string
     benchmarkObject:
+      title: benchmarkObjectSchema
       type: object
       properties:
         id:
@@ -4651,6 +5280,7 @@ components:
           format: date-
           example: '2021-01-01 12:00:00'
     benchmarkMiniObject:
+      title: benchmarkMiniObjectSchema
       type: object
       properties:
         id:
@@ -4700,6 +5330,7 @@ components:
           format: date-
           example: '2021-01-01 12:00:00'
     eventRequestSchema:
+      title: eventRequestSchema
       type: object
       required:
         - event_area
@@ -4769,6 +5400,7 @@ components:
             - Outdoors
             - Entertainment
     loginRequestSchema:
+      title: loginRequestSchema
       type: object
       required:
         - user_email
@@ -4782,6 +5414,7 @@ components:
         key:
           type: string
     authenticateRequestSchema:
+      title: authenticateRequestSchema
       type: object
       required:
         - user_email
@@ -4792,6 +5425,7 @@ components:
         user_password:
           type: string
     benchmarkRequestSchema:
+      title: benchmarkRequestSchema
       type: object
       required:
         - benchmark_title
@@ -4850,6 +5484,8 @@ components:
             - inactive
             - pending
     clusterRequestSchema:
+      description: clusterRequestSchema
+      title: clusterRequestSchema
       type: object
       required:
         - name
@@ -4857,6 +5493,7 @@ components:
         name:
           type: string
     groupRequestSchema:
+      title: groupRequestSchema
       type: object
       required:
         - ug_status
@@ -4925,6 +5562,7 @@ components:
             - 'Yes'
             - 'No'
     hourRequestSchema:
+      title: hourRequestSchema
       type: object
       required:
         - hour_hours
@@ -4973,6 +5611,7 @@ components:
             format: number
             example: "12345"
     userRequestSchema:
+      title: userRequestSchema
       type: object
       required:
         - user_fname
@@ -5021,6 +5660,13 @@ components:
           type: string
         user_ethnicity:
           type: string
+        user_gender:
+          type: string
+          enum:
+            - Male
+            - Female
+            - PreferNotToSay
+            - Other
         user_grad_semester:
           type: string
           enum:
@@ -5047,6 +5693,7 @@ components:
             - imported
             - inactive
     agencyRequestSchema:
+      title: agencyRequestSchema
       type: object
       required:
         - agency_name
@@ -5115,6 +5762,7 @@ components:
             - 'Yes'
             - 'No'
     responseRequestSchema:
+      title: responseRequestSchema
       type: object
       required:
         - need_id
@@ -5168,7 +5816,13 @@ components:
                 inputFieldTest:
                   type: string
                   example: Dark Chox
+        response_date_added:
+          type: string
+          format: date-time
+          example: '2021-01-01 12:30:00'
+          description: Override the default date the response record was added. This can be any date in the past. If not provided, the current date will be used.
     needRequestSchema:
+      title: needRequestSchema
       type: object
       required:
         - agency_id
@@ -5303,6 +5957,7 @@ components:
           items:
             $ref: '#/components/schemas/shiftRequestSchema'
     qualificationRequestSchema:
+      title: qualificationRequestSchema
       type: object
       required:
         - qualification_title
@@ -5388,6 +6043,7 @@ components:
             - 'Yes'
             - 'No'
     teamRequestSchema:
+      title: teamRequestSchema
       type: object
       required:
         - team_title

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Set up the venv + deps from scratch. Idempotent.
+# Usage: ./bootstrap.sh && source env/bin/activate
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ ! -d env ]; then
+  echo ">> creating venv in ./env"
+  python3 -m venv env
+fi
+
+# shellcheck disable=SC1091
+source env/bin/activate
+
+echo ">> installing dependencies"
+pip install --quiet --upgrade pip
+pip install --quiet -r requirements.txt
+# pydantic v1 on python >=3.12 needs this for EmailStr fields to import.
+pip install --quiet email-validator
+
+echo
+echo ">> done. activate the venv with:"
+echo "     source env/bin/activate"
+echo ">> next steps:"
+echo "     python verify_galaxy_creds.py   # confirm API creds"
+echo "     python run_cal_update.py        # sync loop + digest"
+echo "     python run_web.py               # web viewer (needs WEB_PASSWORD in .env)"

--- a/checkin.py
+++ b/checkin.py
@@ -1,0 +1,123 @@
+"""Volunteer check-in status derivation for Galaxy Digital.
+
+The Galaxy Digital API doesn't expose check-in state as a clean flag:
+- `hour_status` reflects manager-approval flow (pending/approved/denied),
+  not whether the volunteer is currently at the kiosk.
+- `hour_date_end` is always populated from the shift's scheduled end, so it
+  is NOT a checkout signal.
+- The only reliable signal is `hour_source`, a free-text audit log that
+  contains substrings like `/kiosk/storeCheckin/` and `/kiosk/storeCheckout/`
+  when the kiosk actions fire.
+
+This module turns hours + responses into a clean status enum.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+import pytz
+
+CHICAGO = pytz.timezone("America/Chicago")
+
+# Status values surfaced to gcal / digest / webpage.
+SIGNED_UP = "signed_up"      # response exists, no hour row yet
+CHECKED_IN = "checked_in"    # at the kiosk, not checked out yet
+CHECKED_OUT = "checked_out"  # full kiosk flow completed
+MANAGER_ENTERED = "manager_entered"  # hours added by a manager; treat as completed
+NO_SHOW = "no_show"          # response exists, no hour, shift end past
+
+STATUS_EMOJI = {
+    SIGNED_UP: "🔘",
+    CHECKED_IN: "🟢",
+    CHECKED_OUT: "🔵",
+    MANAGER_ENTERED: "🟣",
+    NO_SHOW: "🔴",
+}
+
+
+@dataclass
+class HourSignal:
+    """Minimal projection of an /hours row used for status derivation."""
+
+    response_id: str | None
+    user_id: str | None
+    source: str
+    status: str  # raw hour_status
+    date_start: str | None
+    date_end: str | None
+
+    @classmethod
+    def from_api(cls, row: dict) -> "HourSignal":
+        return cls(
+            response_id=str(row["hour_response_id"]) if row.get("hour_response_id") else None,
+            user_id=str(row.get("user", {}).get("id")) if row.get("user") else None,
+            source=(row.get("hour_source") or ""),
+            status=(row.get("hour_status") or ""),
+            date_start=row.get("hour_date_start"),
+            date_end=row.get("hour_date_end"),
+        )
+
+    @property
+    def kiosk_checked_in(self) -> bool:
+        return "/kiosk/storecheckin/" in self.source.lower()
+
+    @property
+    def kiosk_checked_out(self) -> bool:
+        return "/kiosk/storecheckout/" in self.source.lower()
+
+    @property
+    def manager_entered(self) -> bool:
+        s = self.source.lower()
+        return "/manager/" in s and not self.kiosk_checked_in
+
+
+def classify_hour(h: HourSignal) -> str:
+    """Map one hour record to a status. Returns CHECKED_IN/OUT or MANAGER_ENTERED."""
+    if h.kiosk_checked_out:
+        return CHECKED_OUT
+    if h.kiosk_checked_in:
+        return CHECKED_IN
+    if h.manager_entered:
+        return MANAGER_ENTERED
+    # Hours present but no recognizable source -- treat as completed since the
+    # row exists at all, but flag with manager_entered so it's visible.
+    return MANAGER_ENTERED
+
+
+def build_hour_index(hours: Iterable[dict]) -> dict[str, HourSignal]:
+    """Map response_id -> HourSignal. When response_id is missing (rare ~3%),
+    fall back to user_id so the volunteer still shows as present, with the
+    caveat that two same-day same-need shifts for one user become ambiguous.
+
+    Returns a dict keyed by `r:<response_id>` or `u:<user_id>`. Lookups should
+    try the response key first.
+    """
+    idx: dict[str, HourSignal] = {}
+    for row in hours:
+        h = HourSignal.from_api(row)
+        if h.response_id:
+            idx[f"r:{h.response_id}"] = h
+        elif h.user_id:
+            idx.setdefault(f"u:{h.user_id}", h)
+    return idx
+
+
+def status_for(response_id: str, user_id: str, shift_end_iso: str | None,
+               hour_index: dict[str, HourSignal], now: datetime | None = None) -> str:
+    """Resolve status for a single (response, user) row at the current time."""
+    h = hour_index.get(f"r:{response_id}") or hour_index.get(f"u:{user_id}")
+    if h is not None:
+        return classify_hour(h)
+    # No hour row. Decide between SIGNED_UP and NO_SHOW based on shift end.
+    if shift_end_iso:
+        try:
+            end = datetime.strptime(shift_end_iso, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return SIGNED_UP
+        end = CHICAGO.localize(end) if end.tzinfo is None else end
+        current = now or datetime.now(CHICAGO)
+        if current > end:
+            return NO_SHOW
+    return SIGNED_UP

--- a/checkin.py
+++ b/checkin.py
@@ -30,8 +30,8 @@ NO_SHOW = "no_show"          # response exists, no hour, shift end past
 
 STATUS_EMOJI = {
     SIGNED_UP: "🔘",
-    CHECKED_IN: "🟢",
-    CHECKED_OUT: "🔵",
+    CHECKED_IN: "🟡",    # at the kiosk, not yet checked out
+    CHECKED_OUT: "🟢",   # full kiosk flow complete
     MANAGER_ENTERED: "🟣",
     NO_SHOW: "🔴",
 }

--- a/db.py
+++ b/db.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import os
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Iterable, Iterator
 
 import pytz
@@ -308,7 +308,7 @@ def record_status(conn: sqlite3.Connection, response_id: str, shift_id: str | No
     conn.execute(
         "INSERT INTO status_history(response_id,shift_id,user_id,status,observed_at) "
         "VALUES(?,?,?,?,?)",
-        (response_id, shift_id, user_id, status, datetime.utcnow().isoformat(timespec="seconds")),
+        (response_id, shift_id, user_id, status, datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds")),
     )
 
 
@@ -350,7 +350,7 @@ def signups_for_shift(conn: sqlite3.Connection, shift_id: str) -> list[sqlite3.R
 
 def repeat_offenders(conn: sqlite3.Connection, days: int = 30, min_count: int = 2) -> list[sqlite3.Row]:
     """Top users by NO_SHOW count in the last N days."""
-    cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat(timespec="seconds")
+    cutoff = (datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)).isoformat(timespec="seconds")
     return conn.execute(
         """SELECT
               u.id, u.fname, u.lname, u.email,

--- a/db.py
+++ b/db.py
@@ -1,0 +1,366 @@
+"""SQLite store for Galaxy Digital sync state.
+
+Single source of truth for:
+  - users / needs / shifts (descriptive data)
+  - signups (one row per /responses record, keyed by response_id)
+  - hours  (one row per /hours record, keyed by hour id, with derived
+           `classification` from checkin.classify_hour)
+  - status_history (append-only log of (response_id, status, observed_at)
+                    so repeat-offender queries are cheap)
+  - scan_state (key/value bookkeeping for cursors and last-run timestamps)
+
+Why SQLite: the previous JSON file was a full rewrite each refresh; for the
+digest, webpage, and offender tracking we need point-in-time queries, joins,
+and per-shift aggregates -- all painful against a flat JSON list.
+
+Designed to be the bottom layer with no upward dependencies: sync.py drives
+ingest from the API, digest.py and web.py read views.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from typing import Iterable, Iterator
+
+import pytz
+
+import checkin
+
+DB_PATH = os.getenv("GALAXY_DB_PATH", "galaxy_sync.sqlite3")
+CHICAGO = pytz.timezone("America/Chicago")
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id            TEXT PRIMARY KEY,
+    fname         TEXT,
+    lname         TEXT,
+    email         TEXT,
+    phone         TEXT,
+    updated_at    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS needs (
+    id            TEXT PRIMARY KEY,
+    title         TEXT,
+    agency_name   TEXT,
+    updated_at    TEXT
+);
+
+CREATE TABLE IF NOT EXISTS shifts (
+    id            TEXT PRIMARY KEY,
+    need_id       TEXT,
+    start_ts      TEXT,
+    end_ts        TEXT,
+    duration_min  REAL,
+    slots         INTEGER,
+    FOREIGN KEY (need_id) REFERENCES needs(id)
+);
+CREATE INDEX IF NOT EXISTS idx_shifts_start ON shifts(start_ts);
+
+CREATE TABLE IF NOT EXISTS signups (
+    id              TEXT PRIMARY KEY,           -- response_id
+    user_id         TEXT NOT NULL,
+    shift_id        TEXT NOT NULL,
+    need_id         TEXT,
+    response_status TEXT,
+    created_at      TEXT,
+    updated_at      TEXT,
+    FOREIGN KEY (user_id)  REFERENCES users(id),
+    FOREIGN KEY (shift_id) REFERENCES shifts(id)
+);
+CREATE INDEX IF NOT EXISTS idx_signups_shift ON signups(shift_id);
+CREATE INDEX IF NOT EXISTS idx_signups_user  ON signups(user_id);
+
+CREATE TABLE IF NOT EXISTS hours (
+    id              TEXT PRIMARY KEY,
+    response_id     TEXT,
+    user_id         TEXT,
+    need_id         TEXT,
+    source          TEXT,
+    raw_status      TEXT,
+    classification  TEXT,                       -- checked_in|checked_out|manager_entered
+    date_start      TEXT,
+    date_end        TEXT,
+    created_at      TEXT,
+    updated_at      TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_hours_response ON hours(response_id);
+CREATE INDEX IF NOT EXISTS idx_hours_user_day ON hours(user_id, date_start);
+
+CREATE TABLE IF NOT EXISTS status_history (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    response_id   TEXT NOT NULL,
+    shift_id      TEXT,
+    user_id       TEXT,
+    status        TEXT NOT NULL,
+    observed_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_history_resp   ON status_history(response_id);
+CREATE INDEX IF NOT EXISTS idx_history_user   ON status_history(user_id, status);
+
+CREATE TABLE IF NOT EXISTS scan_state (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+@contextmanager
+def connect(path: str = DB_PATH) -> Iterator[sqlite3.Connection]:
+    """Yield a connection with foreign keys enabled and Row factory set.
+
+    Caller is responsible for committing; the context manager closes the
+    connection on exit.
+    """
+    conn = sqlite3.connect(path, isolation_level=None)  # autocommit; we use BEGIN explicitly
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    conn.execute("PRAGMA journal_mode = WAL;")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def init(path: str = DB_PATH) -> None:
+    """Create tables if they don't exist. Idempotent."""
+    with connect(path) as conn:
+        conn.executescript(SCHEMA)
+
+
+# ---------- scan_state -----------------------------------------------------
+
+def get_state(conn: sqlite3.Connection, key: str, default: str | None = None) -> str | None:
+    row = conn.execute("SELECT value FROM scan_state WHERE key = ?", (key,)).fetchone()
+    return row["value"] if row else default
+
+
+def set_state(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO scan_state(key,value) VALUES(?,?) "
+        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        (key, value),
+    )
+
+
+# ---------- ingest helpers -------------------------------------------------
+
+def upsert_user(conn: sqlite3.Connection, u: dict) -> None:
+    conn.execute(
+        """INSERT INTO users(id,fname,lname,email,phone,updated_at)
+           VALUES(:id,:fname,:lname,:email,:phone,:updated_at)
+           ON CONFLICT(id) DO UPDATE SET
+             fname=excluded.fname, lname=excluded.lname,
+             email=excluded.email, phone=excluded.phone,
+             updated_at=excluded.updated_at
+        """,
+        {
+            "id": str(u["id"]),
+            "fname": u.get("user_fname"),
+            "lname": u.get("user_lname"),
+            "email": u.get("user_email"),
+            "phone": u.get("user_phone") or u.get("user_phone_cell"),
+            "updated_at": u.get("updated_at"),
+        },
+    )
+
+
+def upsert_need(conn: sqlite3.Connection, n: dict, agency_name: str | None = None) -> None:
+    """Upsert a need. `agency_name` is taken explicitly because the /responses
+    payload exposes the agency at the response level, while /needs exposes it
+    nested under `agency`. Caller passes whichever it has; we never overwrite
+    a non-null value with NULL.
+    """
+    if not n:
+        return
+    if not agency_name and isinstance(n.get("agency"), dict):
+        agency_name = (n.get("agency") or {}).get("agency_name")
+    conn.execute(
+        """INSERT INTO needs(id,title,agency_name,updated_at)
+           VALUES(:id,:title,:agency,:updated_at)
+           ON CONFLICT(id) DO UPDATE SET
+             title=excluded.title,
+             agency_name=COALESCE(excluded.agency_name, needs.agency_name),
+             updated_at=excluded.updated_at
+        """,
+        {
+            "id": str(n["id"]),
+            "title": n.get("need_title"),
+            "agency": agency_name,
+            "updated_at": n.get("updated_at"),
+        },
+    )
+
+
+def upsert_shift(conn: sqlite3.Connection, s: dict, need_id: str | None) -> None:
+    conn.execute(
+        """INSERT INTO shifts(id,need_id,start_ts,end_ts,duration_min,slots)
+           VALUES(:id,:need_id,:start,:end,:duration,:slots)
+           ON CONFLICT(id) DO UPDATE SET
+             need_id=excluded.need_id,
+             start_ts=excluded.start_ts,
+             end_ts=excluded.end_ts,
+             duration_min=excluded.duration_min,
+             slots=excluded.slots
+        """,
+        {
+            "id": str(s["id"]),
+            "need_id": str(need_id) if need_id else None,
+            "start": s.get("start"),
+            "end": s.get("end"),
+            "duration": float(s["duration"]) if s.get("duration") else None,
+            "slots": int(s["slots"]) if s.get("slots") else None,
+        },
+    )
+
+
+def ingest_response(conn: sqlite3.Connection, r: dict) -> None:
+    """One /responses record -> users + needs + shifts + signups upserts."""
+    user = r.get("user") or {}
+    need = r.get("need") or {}
+    shift = r.get("shift") or {}
+    if not (user and shift):
+        return
+    upsert_user(conn, user)
+    agency_name = None
+    agency = r.get("agency") or {}
+    if isinstance(agency, dict):
+        agency_name = agency.get("agency_name")
+    upsert_need(conn, need, agency_name=agency_name)
+    upsert_shift(conn, shift, need.get("id"))
+    conn.execute(
+        """INSERT INTO signups(id,user_id,shift_id,need_id,response_status,created_at,updated_at)
+           VALUES(:id,:uid,:sid,:nid,:status,:created,:updated)
+           ON CONFLICT(id) DO UPDATE SET
+             user_id=excluded.user_id,
+             shift_id=excluded.shift_id,
+             need_id=excluded.need_id,
+             response_status=excluded.response_status,
+             updated_at=excluded.updated_at
+        """,
+        {
+            "id": str(r["id"]),
+            "uid": str(user["id"]),
+            "sid": str(shift["id"]),
+            "nid": str(need["id"]) if need else None,
+            "status": r.get("response_status"),
+            "created": r.get("created_at") or r.get("response_date_added"),
+            "updated": r.get("updated_at") or r.get("response_date_updated"),
+        },
+    )
+
+
+def ingest_hour(conn: sqlite3.Connection, h: dict) -> None:
+    """One /hours record -> hours upsert + status_history append (if changed)."""
+    user = h.get("user") or {}
+    need = h.get("need") or {}
+    if user:
+        upsert_user(conn, user)
+    if need:
+        upsert_need(conn, need)
+
+    sig = checkin.HourSignal.from_api(h)
+    classification = checkin.classify_hour(sig)
+
+    conn.execute(
+        """INSERT INTO hours(id,response_id,user_id,need_id,source,raw_status,
+                              classification,date_start,date_end,created_at,updated_at)
+           VALUES(:id,:rid,:uid,:nid,:src,:rstat,:cls,:ds,:de,:c,:u)
+           ON CONFLICT(id) DO UPDATE SET
+             source=excluded.source,
+             raw_status=excluded.raw_status,
+             classification=excluded.classification,
+             date_start=excluded.date_start,
+             date_end=excluded.date_end,
+             updated_at=excluded.updated_at
+        """,
+        {
+            "id": str(h["id"]),
+            "rid": sig.response_id,
+            "uid": sig.user_id,
+            "nid": str(need["id"]) if need else None,
+            "src": sig.source,
+            "rstat": sig.status,
+            "cls": classification,
+            "ds": sig.date_start,
+            "de": sig.date_end,
+            "c": h.get("created_at"),
+            "u": h.get("updated_at"),
+        },
+    )
+
+
+def record_status(conn: sqlite3.Connection, response_id: str, shift_id: str | None,
+                  user_id: str | None, status: str) -> None:
+    """Append to status_history if this status differs from the most recent one
+    for the same response. Idempotent and cheap.
+    """
+    row = conn.execute(
+        "SELECT status FROM status_history WHERE response_id = ? "
+        "ORDER BY id DESC LIMIT 1",
+        (response_id,),
+    ).fetchone()
+    if row and row["status"] == status:
+        return
+    conn.execute(
+        "INSERT INTO status_history(response_id,shift_id,user_id,status,observed_at) "
+        "VALUES(?,?,?,?,?)",
+        (response_id, shift_id, user_id, status, datetime.utcnow().isoformat(timespec="seconds")),
+    )
+
+
+# ---------- query helpers --------------------------------------------------
+
+def shifts_for_day(conn: sqlite3.Connection, day: datetime | None = None) -> list[sqlite3.Row]:
+    """Shifts whose start falls on the given local day (default: today CT)."""
+    day = (day or datetime.now(CHICAGO)).astimezone(CHICAGO)
+    start = day.replace(hour=0, minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+    end = (day + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0).strftime("%Y-%m-%d %H:%M:%S")
+    return conn.execute(
+        """SELECT s.*, n.title, n.agency_name
+           FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+           WHERE s.start_ts >= ? AND s.start_ts < ?
+           ORDER BY s.start_ts
+        """,
+        (start, end),
+    ).fetchall()
+
+
+def signups_for_shift(conn: sqlite3.Connection, shift_id: str) -> list[sqlite3.Row]:
+    """Return (signup x user x latest_hour) join for one shift."""
+    return conn.execute(
+        """SELECT
+              sg.id            AS response_id,
+              u.id             AS user_id,
+              u.fname, u.lname, u.email,
+              h.classification, h.source, h.date_start, h.date_end,
+              h.updated_at     AS hour_updated_at
+           FROM signups sg
+           JOIN users u ON u.id = sg.user_id
+           LEFT JOIN hours h ON h.response_id = sg.id
+           WHERE sg.shift_id = ?
+           ORDER BY u.lname, u.fname
+        """,
+        (shift_id,),
+    ).fetchall()
+
+
+def repeat_offenders(conn: sqlite3.Connection, days: int = 30, min_count: int = 2) -> list[sqlite3.Row]:
+    """Top users by NO_SHOW count in the last N days."""
+    cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat(timespec="seconds")
+    return conn.execute(
+        """SELECT
+              u.id, u.fname, u.lname, u.email,
+              COUNT(*) AS no_shows
+           FROM status_history h
+           JOIN users u ON u.id = h.user_id
+           WHERE h.status = ? AND h.observed_at >= ?
+           GROUP BY u.id
+           HAVING no_shows >= ?
+           ORDER BY no_shows DESC, u.lname
+        """,
+        (checkin.NO_SHOW, cutoff, min_count),
+    ).fetchall()

--- a/db.py
+++ b/db.py
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS needs (
     id            TEXT PRIMARY KEY,
     title         TEXT,
     agency_name   TEXT,
+    location      TEXT,      -- composed from need_address/city/state/postal
     updated_at    TEXT
 );
 
@@ -126,9 +127,20 @@ def connect(path: str = DB_PATH) -> Iterator[sqlite3.Connection]:
 
 
 def init(path: str = DB_PATH) -> None:
-    """Create tables if they don't exist. Idempotent."""
+    """Create tables if they don't exist. Idempotent.
+
+    Includes a lightweight column-add migration for existing databases
+    that pre-date the `needs.location` column.
+    """
     with connect(path) as conn:
         conn.executescript(SCHEMA)
+        _migrate_add_column(conn, "needs", "location", "TEXT")
+
+
+def _migrate_add_column(conn: sqlite3.Connection, table: str, col: str, decl: str) -> None:
+    cols = {r["name"] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    if col not in cols:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
 
 
 # ---------- scan_state -----------------------------------------------------
@@ -168,28 +180,57 @@ def upsert_user(conn: sqlite3.Connection, u: dict) -> None:
     )
 
 
+def compose_location(n: dict) -> str | None:
+    """Build a single-line address string from a /needs payload.
+
+    Skips empty pieces, returns None when the need has no address at all
+    (e.g. virtual_need=Yes events). Format mimics what Google Maps will
+    happily geocode: "street, city, ST zip".
+    """
+    if not n:
+        return None
+    street_bits = [n.get("need_address"), n.get("need_address2")]
+    street = ", ".join(s for s in street_bits if s and s.strip())
+    city = (n.get("need_city") or "").strip()
+    state = (n.get("need_state") or "").strip()
+    postal = (n.get("need_postal") or "").strip()
+    csz_parts = [city]
+    if state or postal:
+        csz_parts.append(f"{state} {postal}".strip())
+    city_state_zip = ", ".join(p for p in csz_parts if p)
+    pieces = [p for p in (street, city_state_zip) if p]
+    return ", ".join(pieces) if pieces else None
+
+
 def upsert_need(conn: sqlite3.Connection, n: dict, agency_name: str | None = None) -> None:
     """Upsert a need. `agency_name` is taken explicitly because the /responses
     payload exposes the agency at the response level, while /needs exposes it
     nested under `agency`. Caller passes whichever it has; we never overwrite
     a non-null value with NULL.
+
+    `location` is composed from need_address/city/state/postal. The same
+    COALESCE pattern preserves a previously-known location when a later
+    upsert (e.g. via /responses, which carries no address) has none.
     """
     if not n:
         return
     if not agency_name and isinstance(n.get("agency"), dict):
         agency_name = (n.get("agency") or {}).get("agency_name")
+    location = compose_location(n)
     conn.execute(
-        """INSERT INTO needs(id,title,agency_name,updated_at)
-           VALUES(:id,:title,:agency,:updated_at)
+        """INSERT INTO needs(id,title,agency_name,location,updated_at)
+           VALUES(:id,:title,:agency,:location,:updated_at)
            ON CONFLICT(id) DO UPDATE SET
              title=excluded.title,
              agency_name=COALESCE(excluded.agency_name, needs.agency_name),
+             location=COALESCE(excluded.location, needs.location),
              updated_at=excluded.updated_at
         """,
         {
             "id": str(n["id"]),
             "title": n.get("need_title"),
             "agency": agency_name,
+            "location": location,
             "updated_at": n.get("updated_at"),
         },
     )

--- a/demo_gcal_push.py
+++ b/demo_gcal_push.py
@@ -1,0 +1,85 @@
+"""One-shot visible push to a test calendar so a human can eyeball the
+rendering. Leaves the event in place; rerun with --delete <event_id> to
+clean up afterwards.
+
+Usage:
+    GCAL_TEST_CALENDAR_ID="<id>" python demo_gcal_push.py
+    GCAL_TEST_CALENDAR_ID="<id>" python demo_gcal_push.py --delete <event_id>
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import checkin
+import gcal
+
+CAL = os.getenv("GCAL_TEST_CALENDAR_ID") or os.getenv("CALENDAR_ID")
+
+
+def push(svc):
+    event_id = f"demoshift{uuid.uuid4().hex}"
+    # Slot the event for tomorrow at 2 PM CT so it's findable in the
+    # week view without polluting "today".
+    start = (datetime.now() + timedelta(days=1)).replace(hour=14, minute=0, second=0, microsecond=0)
+    shift = {
+        "id": event_id,
+        "title": "Kayak River Clean Up - Wild Mile (demo)",
+        "slots_filled": 4,
+        "slots": 6,
+        "start_time": start,
+        "end_time": start + timedelta(hours=2),
+        "users": [
+            {"id": "u1", "response_id": "r1", "user_fname": "Alice",
+             "user_lname": "Demo", "user_email": "alice@example.test",
+             "checkin_status": checkin.CHECKED_IN},     # 🟡 at kiosk now
+            {"id": "u2", "response_id": "r2", "user_fname": "Bob",
+             "user_lname": "Demo", "user_email": "bob@example.test",
+             "checkin_status": checkin.CHECKED_OUT},    # 🟢 wrapped
+            {"id": "u3", "response_id": "r3", "user_fname": "Carol",
+             "user_lname": "Demo", "user_email": "carol@example.test",
+             "checkin_status": checkin.SIGNED_UP},      # 🔘 pending
+            {"id": "u4", "response_id": "r4", "user_fname": "Dave",
+             "user_lname": "Demo", "user_email": "dave@example.test",
+             "checkin_status": checkin.NO_SHOW},        # 🔴 missed
+        ],
+    }
+    gcal.update_calendar_events([shift], svc, calendar_id=CAL, add_attendees=False)
+    got = svc.events().get(calendarId=CAL, eventId=event_id).execute()
+    print(f"\n✓ created event id: {event_id}")
+    print(f"✓ summary:  {got['summary']}")
+    print(f"✓ when:     {got['start']['dateTime']} → {got['end']['dateTime']}")
+    print(f"✓ link:     {got.get('htmlLink')}")
+    print()
+    print("Description posted:")
+    print(got.get("description", "(no description)"))
+    print()
+    print(f"To clean up:  python demo_gcal_push.py --delete {event_id}")
+
+
+def delete(svc, event_id: str):
+    svc.events().delete(calendarId=CAL, eventId=event_id).execute()
+    print(f"deleted {event_id}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--delete", metavar="EVENT_ID", help="delete an event id and exit")
+    args = p.parse_args()
+    if not CAL:
+        raise SystemExit("set GCAL_TEST_CALENDAR_ID (or CALENDAR_ID) first")
+    svc = gcal.get_service()
+    if args.delete:
+        delete(svc, args.delete)
+    else:
+        push(svc)
+
+
+if __name__ == "__main__":
+    main()

--- a/digest.py
+++ b/digest.py
@@ -1,0 +1,289 @@
+"""Daily/weekly digest email of who signed up, who showed up, and who didn't.
+
+Reads from SQLite (db.py). No Galaxy Digital API calls -- sync.py is
+responsible for keeping the store fresh, the digest just renders.
+
+Config via environment (all optional unless you actually want to send mail):
+  DIGEST_EMAIL_TO       comma-separated recipients (required to actually send)
+  DIGEST_EMAIL_FROM     default: same as SMTP_USER
+  DIGEST_SUBJECT_PREFIX default: 'Galaxy Digital'
+  DIGEST_LOOKBACK_DAYS  default: 1 (one-day digest = "today")
+  DIGEST_REPEAT_WINDOW  days for repeat-offender section (default 30)
+  DIGEST_REPEAT_MIN     min no-shows to appear in repeat list (default 2)
+  SMTP_HOST / SMTP_PORT / SMTP_USER / SMTP_PASS / SMTP_TLS  (TLS default 'yes')
+
+Render-only mode: digest.render_html() returns a string for the webpage to
+embed or for `python -m digest --dry-run` to print.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import smtplib
+import ssl
+from datetime import datetime, timedelta
+from email.message import EmailMessage
+from typing import Iterable
+
+import pytz
+
+import checkin
+import db
+
+CHICAGO = pytz.timezone("America/Chicago")
+
+
+def _fmt_time(s: str | None) -> str:
+    """'2026-05-20 13:00:00' -> '1:00 PM'. Returns '—' if unparseable."""
+    if not s:
+        return "—"
+    try:
+        return datetime.strptime(s, "%Y-%m-%d %H:%M:%S").strftime("%-I:%M %p")
+    except (ValueError, TypeError):
+        return s
+
+
+def _checkin_time_from_source(row) -> str:
+    """The actual kiosk Checkin happens at hour.created_at when source is kiosk;
+    fall back to date_start otherwise.
+    """
+    src = (row["source"] or "").lower() if "source" in row.keys() else ""
+    if "/kiosk/storecheckin/" in src:
+        return _fmt_time(row["date_start"])
+    return _fmt_time(row["date_start"])
+
+
+def _checkout_time(row) -> str | None:
+    src = (row["source"] or "").lower() if "source" in row.keys() else ""
+    if "/kiosk/storecheckout/" in src:
+        # Kiosk-out time isn't broken out in the API; date_end is the best we have.
+        return _fmt_time(row["date_end"])
+    return None
+
+
+def collect(days_back: int = 1) -> dict:
+    """Gather data for the digest. Returns a render-ready dict."""
+    now = datetime.now(CHICAGO)
+    start = (now - timedelta(days=days_back)).replace(hour=0, minute=0, second=0, microsecond=0)
+    end_ts = now.strftime("%Y-%m-%d %H:%M:%S")
+    start_ts = start.strftime("%Y-%m-%d %H:%M:%S")
+
+    repeat_window = int(os.getenv("DIGEST_REPEAT_WINDOW", "30"))
+    repeat_min = int(os.getenv("DIGEST_REPEAT_MIN", "2"))
+
+    with db.connect() as conn:
+        shifts = conn.execute(
+            """SELECT s.id, s.start_ts, s.end_ts, s.slots,
+                      n.title, n.agency_name
+               FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+               WHERE s.start_ts >= ? AND s.start_ts < ?
+               ORDER BY s.start_ts
+            """,
+            (start_ts, end_ts),
+        ).fetchall()
+
+        out_shifts = []
+        totals = {checkin.SIGNED_UP: 0, checkin.CHECKED_IN: 0,
+                  checkin.CHECKED_OUT: 0, checkin.MANAGER_ENTERED: 0,
+                  checkin.NO_SHOW: 0}
+        for s in shifts:
+            rows = db.signups_for_shift(conn, s["id"])
+            people = []
+            counts = {checkin.SIGNED_UP: 0, checkin.CHECKED_IN: 0,
+                      checkin.CHECKED_OUT: 0, checkin.MANAGER_ENTERED: 0,
+                      checkin.NO_SHOW: 0}
+            for r in rows:
+                status = r["classification"]
+                if not status:
+                    # No hour row -> signed_up unless shift ended.
+                    status = (checkin.NO_SHOW
+                              if s["end_ts"] and s["end_ts"] < now.strftime("%Y-%m-%d %H:%M:%S")
+                              else checkin.SIGNED_UP)
+                counts[status] = counts.get(status, 0) + 1
+                totals[status] = totals.get(status, 0) + 1
+                people.append({
+                    "name": f"{r['fname'] or ''} {r['lname'] or ''}".strip(),
+                    "email": r["email"] or "",
+                    "status": status,
+                    "emoji": checkin.STATUS_EMOJI.get(status, "🔘"),
+                    "checkin_time": _checkin_time_from_source(r) if status in (checkin.CHECKED_IN, checkin.CHECKED_OUT, checkin.MANAGER_ENTERED) else None,
+                    "checkout_time": _checkout_time(r) if status == checkin.CHECKED_OUT else None,
+                })
+            out_shifts.append({
+                "id": s["id"],
+                "title": s["title"] or "(no title)",
+                "agency": s["agency_name"] or "",
+                "start": _fmt_time(s["start_ts"]),
+                "end": _fmt_time(s["end_ts"]),
+                "date": (s["start_ts"] or "")[:10],
+                "slots": s["slots"],
+                "counts": counts,
+                "people": people,
+            })
+
+        offenders = db.repeat_offenders(conn, days=repeat_window, min_count=repeat_min)
+
+    return {
+        "generated_at": now.strftime("%Y-%m-%d %H:%M %Z"),
+        "lookback_days": days_back,
+        "start_date": start.strftime("%Y-%m-%d"),
+        "end_date": now.strftime("%Y-%m-%d"),
+        "totals": totals,
+        "shifts": out_shifts,
+        "repeat_window_days": repeat_window,
+        "repeat_offenders": [
+            {
+                "name": f"{r['fname'] or ''} {r['lname'] or ''}".strip(),
+                "email": r["email"] or "",
+                "no_shows": r["no_shows"],
+            }
+            for r in offenders
+        ],
+    }
+
+
+CSS = """
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       color: #222; max-width: 820px; margin: 1em auto; padding: 0 1em; }
+h1, h2 { color: #2a4d69; }
+.summary { background: #f4f6f9; padding: 0.75em 1em; border-radius: 6px;
+           display: flex; gap: 1.4em; flex-wrap: wrap; }
+.summary span { font-size: 0.95em; }
+.shift { border: 1px solid #e2e4e8; border-radius: 6px; margin: 1em 0; padding: 0.8em 1em; }
+.shift h3 { margin: 0 0 0.25em 0; }
+.meta { color: #666; font-size: 0.9em; margin-bottom: 0.5em; }
+table { width: 100%; border-collapse: collapse; font-size: 0.93em; }
+th, td { padding: 4px 8px; text-align: left; border-bottom: 1px solid #eee; }
+.no-show { background: #fff2f2; }
+.offenders th, .offenders td { padding: 4px 12px; }
+"""
+
+
+def render_html(data: dict) -> str:
+    t = data["totals"]
+    parts = [f"<style>{CSS}</style>"]
+    parts.append(f"<h1>Volunteer digest · {data['start_date']} → {data['end_date']}</h1>")
+    parts.append(f"<p class='meta'>Generated {data['generated_at']}</p>")
+    parts.append("<div class='summary'>")
+    for k in (checkin.SIGNED_UP, checkin.CHECKED_IN, checkin.CHECKED_OUT,
+              checkin.MANAGER_ENTERED, checkin.NO_SHOW):
+        parts.append(f"<span>{checkin.STATUS_EMOJI[k]} <b>{t.get(k,0)}</b> {k.replace('_',' ')}</span>")
+    parts.append("</div>")
+
+    if not data["shifts"]:
+        parts.append("<p><em>No shifts in this window.</em></p>")
+    for s in data["shifts"]:
+        c = s["counts"]
+        parts.append("<div class='shift'>")
+        parts.append(f"<h3>{s['title']}</h3>")
+        parts.append(f"<div class='meta'>{s['agency']} · {s['date']} {s['start']}–{s['end']} · "
+                     f"{sum(c.values())}/{s['slots']} filled · "
+                     f"🟢 {c.get(checkin.CHECKED_IN,0)} in · "
+                     f"🔵 {c.get(checkin.CHECKED_OUT,0)} done · "
+                     f"🔴 {c.get(checkin.NO_SHOW,0)} no-show</div>")
+        if s["people"]:
+            parts.append("<table><thead><tr><th></th><th>Volunteer</th><th>Email</th>"
+                         "<th>In</th><th>Out</th></tr></thead><tbody>")
+            for p in s["people"]:
+                cls = " class='no-show'" if p["status"] == checkin.NO_SHOW else ""
+                parts.append(f"<tr{cls}><td>{p['emoji']}</td><td>{p['name']}</td>"
+                             f"<td>{p['email']}</td>"
+                             f"<td>{p['checkin_time'] or ''}</td>"
+                             f"<td>{p['checkout_time'] or ''}</td></tr>")
+            parts.append("</tbody></table>")
+        parts.append("</div>")
+
+    parts.append(f"<h2>Repeat no-shows · last {data['repeat_window_days']} days</h2>")
+    if data["repeat_offenders"]:
+        parts.append("<table class='offenders'><thead><tr><th>Volunteer</th><th>Email</th>"
+                     "<th>No-shows</th></tr></thead><tbody>")
+        for o in data["repeat_offenders"]:
+            parts.append(f"<tr><td>{o['name']}</td><td>{o['email']}</td><td>{o['no_shows']}</td></tr>")
+        parts.append("</tbody></table>")
+    else:
+        parts.append("<p><em>None.</em></p>")
+    return "\n".join(parts)
+
+
+def render_text(data: dict) -> str:
+    """Plain-text fallback for the multipart email."""
+    out = [f"Volunteer digest · {data['start_date']} → {data['end_date']}",
+           f"Generated {data['generated_at']}", ""]
+    t = data["totals"]
+    out.append(f"Totals: signed_up={t.get(checkin.SIGNED_UP,0)} "
+               f"checked_in={t.get(checkin.CHECKED_IN,0)} "
+               f"checked_out={t.get(checkin.CHECKED_OUT,0)} "
+               f"manager={t.get(checkin.MANAGER_ENTERED,0)} "
+               f"no_show={t.get(checkin.NO_SHOW,0)}")
+    out.append("")
+    for s in data["shifts"]:
+        out.append(f"## {s['title']}  ({s['agency']})")
+        out.append(f"   {s['date']} {s['start']}–{s['end']}  ({sum(s['counts'].values())}/{s['slots']})")
+        for p in s["people"]:
+            extra = []
+            if p["checkin_time"]:  extra.append(f"in {p['checkin_time']}")
+            if p["checkout_time"]: extra.append(f"out {p['checkout_time']}")
+            extra_s = f"  [{', '.join(extra)}]" if extra else ""
+            out.append(f"   {p['emoji']} {p['name']:25s} {p['status']:18s} {p['email']}{extra_s}")
+        out.append("")
+    out.append(f"Repeat no-shows (last {data['repeat_window_days']}d):")
+    for o in data["repeat_offenders"]:
+        out.append(f"  {o['no_shows']}x  {o['name']:25s} {o['email']}")
+    return "\n".join(out)
+
+
+def send(data: dict, html: str, text: str) -> bool:
+    """Send the digest. Returns True on success, False on configuration miss."""
+    to = os.getenv("DIGEST_EMAIL_TO", "").strip()
+    if not to:
+        return False
+    host = os.getenv("SMTP_HOST", "").strip()
+    if not host:
+        return False
+    port = int(os.getenv("SMTP_PORT", "587"))
+    user = os.getenv("SMTP_USER", "").strip()
+    password = os.getenv("SMTP_PASS", "")
+    use_tls = os.getenv("SMTP_TLS", "yes").lower() != "no"
+    sender = os.getenv("DIGEST_EMAIL_FROM", user or to)
+    prefix = os.getenv("DIGEST_SUBJECT_PREFIX", "Galaxy Digital")
+
+    msg = EmailMessage()
+    msg["Subject"] = f"{prefix}: digest {data['start_date']} → {data['end_date']}"
+    msg["From"] = sender
+    msg["To"] = to
+    msg.set_content(text)
+    msg.add_alternative(html, subtype="html")
+
+    if use_tls:
+        with smtplib.SMTP(host, port, timeout=30) as s:
+            s.starttls(context=ssl.create_default_context())
+            if user:
+                s.login(user, password)
+            s.send_message(msg)
+    else:
+        with smtplib.SMTP_SSL(host, port, timeout=30, context=ssl.create_default_context()) as s:
+            if user:
+                s.login(user, password)
+            s.send_message(msg)
+    return True
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--days", type=int, default=int(os.getenv("DIGEST_LOOKBACK_DAYS", "1")))
+    p.add_argument("--dry-run", action="store_true", help="render to stdout, don't email")
+    p.add_argument("--format", choices=("html", "text"), default="text")
+    args = p.parse_args()
+
+    data = collect(days_back=args.days)
+    html = render_html(data)
+    text = render_text(data)
+    if args.dry_run or not os.getenv("DIGEST_EMAIL_TO"):
+        print(text if args.format == "text" else html)
+        return
+    ok = send(data, html, text)
+    print("sent" if ok else "skipped (no DIGEST_EMAIL_TO or SMTP_HOST)")
+
+
+if __name__ == "__main__":
+    main()

--- a/gcal.py
+++ b/gcal.py
@@ -134,6 +134,12 @@ def update_calendar_events(shifts, service, calendar_id='primary', add_attendees
             },
             'colorId': change_color(shift['slots_filled']),
         }
+        # Google Calendar's `location` field powers "Open in Maps" on
+        # mobile and the geocoded preview on desktop. Only set it when
+        # the need had an address; virtual events stay locationless.
+        loc = shift.get('location')
+        if loc:
+            event['location'] = loc
         # Get the list of event attendees
         if add_attendees:
             event['attendees'] = [{'email': 'test@urbanriv.org'}]
@@ -154,6 +160,12 @@ def update_calendar_events(shifts, service, calendar_id='primary', add_attendees
                 if error.resp.status == 409:
                     logger.error(f"Event with this ID already exists. Consider updating it instead.")
                     break
+                elif error.resp.status == 400:
+                    # Almost always a malformed event id (Google requires
+                    # RFC2938 base32hex: lowercase a-v + 0-9). Re-raise so
+                    # callers see the failure instead of silently moving on.
+                    logger.error(f"Insert rejected for event id {event_id!r}: {error}")
+                    raise
                 elif error.resp.status == 403 and 'rateLimitExceeded' in str(error):
                     wait_time = (2 ** attempt)  # Exponential backoff: 2, 4, 8, 16, 32 seconds
                     logger.error(f"Rate limit exceeded. Attempt {attempt}/{MAX_RETRIES}. Waiting {wait_time} seconds before retrying...")

--- a/gcal.py
+++ b/gcal.py
@@ -16,21 +16,63 @@ import checkin
 # If modifying these SCOPES, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/calendar']
 
-creds = None
-if os.path.exists('token.json'):
-    creds = Credentials.from_authorized_user_file('token.json')
-if not creds or not creds.valid:
-    if creds and creds.expired and creds.refresh_token:
-        creds.refresh(Request())
-    else:
-        flow = InstalledAppFlow.from_client_secrets_file(
-            'credentials.json', SCOPES)
-        creds = flow.run_local_server(port=0)
-    # Save the credentials for the next run
-    with open('token.json', 'w') as token:
-        token.write(creds.to_json())
+# OAuth used to run at module import, which made `import gcal` open a browser
+# whenever token.json was missing or stale. That meant every smoke test,
+# digest preview, and standalone tool had to stub the module out. Now the
+# credentials and service are built lazily on first use; importing gcal is
+# free.
 
-service = build('calendar', 'v3', credentials=creds)
+_service = None
+_token_path = os.getenv('GCAL_TOKEN_PATH', 'token.json')
+_creds_path = os.getenv('GCAL_CREDS_PATH', 'credentials.json')
+
+
+def _load_credentials() -> Credentials:
+    creds = None
+    if os.path.exists(_token_path):
+        creds = Credentials.from_authorized_user_file(_token_path)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not os.path.exists(_creds_path):
+                raise FileNotFoundError(
+                    f"No {_token_path} and no {_creds_path} -- cannot open OAuth flow. "
+                    "Set GCAL_TOKEN_PATH / GCAL_CREDS_PATH or place these files in cwd."
+                )
+            flow = InstalledAppFlow.from_client_secrets_file(_creds_path, SCOPES)
+            creds = flow.run_local_server(port=0)
+        with open(_token_path, 'w') as token:
+            token.write(creds.to_json())
+    return creds
+
+
+def get_service():
+    """Return the cached Calendar v3 service, building it on first call.
+
+    Side effects (OAuth flow / disk write) happen only here, so importing
+    this module is free. Callers that previously read `gcal.service`
+    directly should switch to `gcal.get_service()`.
+    """
+    global _service
+    if _service is None:
+        _service = build('calendar', 'v3', credentials=_load_credentials())
+    return _service
+
+
+class _ServiceProxy:
+    """Backwards-compat shim so legacy `gcal.service` reads still work,
+    but no OAuth runs until something actually calls a method on it.
+
+    Once nothing references `gcal.service` directly, this proxy and the
+    module-level `service` alias can be deleted; callers should use
+    get_service() instead.
+    """
+    def __getattr__(self, item):
+        return getattr(get_service(), item)
+
+
+service = _ServiceProxy()
 def convert_to_iso(datetime_str):
     return datetime_str.replace(" ", "T")
 

--- a/gcal.py
+++ b/gcal.py
@@ -10,6 +10,8 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 import time
 
+import checkin
+
 
 # If modifying these SCOPES, delete the file token.json.
 SCOPES = ['https://www.googleapis.com/auth/calendar']
@@ -33,16 +35,20 @@ def convert_to_iso(datetime_str):
     return datetime_str.replace(" ", "T")
 
 def create_attendees_list(users):
-    attendees = 'Signups: \n'
+    """Build the description block listing signups with status emoji.
+
+    Status comes from checkin.classify_hour() and is one of:
+      signed_up | checked_in | checked_out | manager_entered | no_show
+    See checkin.py for the rationale -- hour_status/hour_date_end are NOT
+    reliable real-time signals; only hour_source is.
+    """
+    lines = ['Signups:']
     for user in users:
-        if 'status' in user:
-            if user['checkin_status'] == 'pending':
-                attendees += f"🟡 {user['user_fname']} {user['user_lname']} email: {user['user_email']} \n"
-            elif user['checkin_status'] == 'approved':
-                attendees += f"🟢 {user['user_fname']} {user['user_lname']} email: {user['user_email']} \n"
-        else:
-            attendees += f"🔘 {user['user_fname']} {user['user_lname']} email: {user['user_email']} \n"
-    return attendees
+        status = user.get('checkin_status') or checkin.SIGNED_UP
+        emoji = checkin.STATUS_EMOJI.get(status, '🔘')
+        lines.append(f"{emoji} {user.get('user_fname','')} {user.get('user_lname','')} "
+                     f"email: {user.get('user_email','')}")
+    return '\n'.join(lines) + '\n'
 
 #Hacky way to change the color of the event, https://lukeboyle.com/blog/posts/google-calendar-api-color-id
 def change_color(attendees):

--- a/get_connected.py
+++ b/get_connected.py
@@ -162,8 +162,9 @@ class GalaxyAPI:
 
         with open("transformed_responses.json", "w") as f:
             json.dump(tr, f, default=str)
-        gcal.get_calendars(gcal.service)
-        gcal.update_calendar_events(tr, gcal.service, calendar_id=self.calendar_id, add_attendees=False)
+        svc = gcal.get_service()
+        gcal.get_calendars(svc)
+        gcal.update_calendar_events(tr, svc, calendar_id=self.calendar_id, add_attendees=False)
         logger.debug("updated_responses complete")
 
     def user_checkin_update(self):
@@ -255,8 +256,9 @@ class GalaxyAPI:
                     if isinstance(shift['end_time'], str):
                         shift['end_time'] = datetime.strptime(shift['end_time'], '%Y-%m-%d %H:%M:%S')
                 
-                gcal.get_calendars(gcal.service)
-                gcal.update_calendar_events(shifts_to_update, gcal.service, calendar_id=self.calendar_id, add_attendees=False)
+                svc = gcal.get_service()
+                gcal.get_calendars(svc)
+                gcal.update_calendar_events(shifts_to_update, svc, calendar_id=self.calendar_id, add_attendees=False)
         except Exception as e:
             logger.error(f"Error updating checkin shifts: {e}")
         return shifts_to_update

--- a/get_connected.py
+++ b/get_connected.py
@@ -196,7 +196,7 @@ class GalaxyAPI:
                 window_end = (current_time + timedelta(hours=20)).strftime("%Y-%m-%d %H:%M:%S")
                 shifts = conn.execute(
                     """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
-                              s.need_id, n.title
+                              s.need_id, n.title, n.location
                        FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
                        WHERE s.start_ts BETWEEN ? AND ?
                     """,
@@ -269,7 +269,10 @@ class GalaxyAPI:
                 gcal.get_calendars(svc)
                 gcal.update_calendar_events(shifts_to_update, svc, calendar_id=self.calendar_id, add_attendees=False)
         except Exception as e:
-            logger.error(f"Error updating checkin shifts: {e}")
+            # Log with traceback. The previous bare message silently swallowed
+            # a KeyError("location") for half a release, which made the
+            # scan-loop appear functional while pushing zero shifts.
+            logger.exception(f"Error updating checkin shifts: {e}")
         return shifts_to_update
     
     def get_next_shift(self):

--- a/get_connected.py
+++ b/get_connected.py
@@ -54,38 +54,45 @@ class GalaxyAPI:
         all_data = []
         records = 0
         page_return = 150
-        headers = {
-            'Accept': 'application/json',
-            'Authorization': f"Bearer {self.token}",
-        }
         query = {
             'per_page': 150,
             'show_inactive': 'No',
         }
-        
+
         # Merge additional parameters if provided
         if additional_params:
             query.update(additional_params)
-        
+
+        relogin_attempts = 0
         while True:
             if records != 0:
                 query['since_id'] = all_data[-1]['id']
                 logger.debug(f"Since ID: {query['since_id']}")
-            
+
+            headers = {
+                'Accept': 'application/json',
+                'Authorization': f"Bearer {self.token}",
+            }
             response = requests.get(f"{self.url}{url_path}", headers=headers, json=query)
-            
+
             if response.status_code == 200:
                 data = response.json()
-                all_data.extend(data.get('data'))  # If the response was successful, no Exception will be raised
+                all_data.extend(data.get('data'))
                 records += len(data.get('data'))
                 page_return = len(data.get('data'))
-                # logger.debug(f"Page: {page_return}, Records: {records}")
-                # logger.info(f"Data: {data.get('data')}")
                 if page_return != 150:
                     logger.debug(f"Fin Page: {page_return}, Records: {records}")
                     return all_data
+            elif response.status_code == 401 and relogin_attempts == 0:
+                # Token expired mid-paginate. Re-login once and retry the
+                # current page (without bumping records, so the same
+                # since_id is used). Avoids a hard fail after long runs.
+                logger.warning("401 on /%s -- re-authenticating once", url_path)
+                self.token = self.login()
+                relogin_attempts += 1
+                continue
             else:
-                response.raise_for_status()  # Raises stored HTTPError, if one occurred.
+                response.raise_for_status()
 
     def get_needs(self):
         url_path = 'needs'
@@ -132,7 +139,7 @@ class GalaxyAPI:
         with db.connect() as conn:
             shifts = conn.execute(
                 """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
-                          s.need_id, n.title
+                          s.need_id, n.title, n.location
                    FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
                 """,
             ).fetchall()
@@ -156,6 +163,7 @@ class GalaxyAPI:
                     "duration": s["duration_min"],
                     "slots": s["slots"],
                     "title": s["title"],
+                    "location": s["location"],
                     "users": users,
                     "slots_filled": len(users),
                 })
@@ -241,6 +249,7 @@ class GalaxyAPI:
                         "duration": s["duration_min"],
                         "slots": s["slots"],
                         "title": s["title"],
+                        "location": s["location"],
                         "users": users,
                         "slots_filled": len(users),
                     })

--- a/get_connected.py
+++ b/get_connected.py
@@ -135,6 +135,10 @@ class GalaxyAPI:
 
         # Build the shift roster from SQLite for gcal. Same dict shape the
         # gcal layer already expects (start_time / end_time / users / etc).
+        # We also fingerprint each shift here so the 2h refresh only pushes
+        # the ones whose displayed content actually changed -- otherwise we
+        # would UPDATE every event in the calendar (~1500 for this org)
+        # every refresh, which works but is noisy and chews quota.
         tr: list[dict] = []
         with db.connect() as conn:
             shifts = conn.execute(
@@ -155,6 +159,18 @@ class GalaxyAPI:
                         "user_email": sg["email"],
                         "checkin_status": sg["classification"] or checkin.SIGNED_UP,
                     })
+                # Fingerprint = (slot count, location, user statuses).
+                fp_input = "|".join([
+                    str(s["slots"] or ""),
+                    s["location"] or "",
+                    ",".join(sorted(f"{u['response_id']}:{u['checkin_status']}" for u in users)),
+                ])
+                fp = hashlib.sha1(fp_input.encode()).hexdigest()
+                key = f"gcal_fp:{s['id']}"
+                prev_fp = db.get_state(conn, key)
+                if prev_fp == fp:
+                    continue
+                db.set_state(conn, key, fp)
                 tr.append({
                     "id": s["id"],
                     "start_time": datetime.strptime(s["start_ts"], "%Y-%m-%d %H:%M:%S"),
@@ -170,6 +186,10 @@ class GalaxyAPI:
 
         with open("transformed_responses.json", "w") as f:
             json.dump(tr, f, default=str)
+        if not tr:
+            logger.debug("update_responses: nothing changed since last push")
+            return
+        logger.info(f"update_responses: pushing {len(tr)} changed shift(s) to gcal")
         svc = gcal.get_service()
         gcal.get_calendars(svc)
         gcal.update_calendar_events(tr, svc, calendar_id=self.calendar_id, add_attendees=False)

--- a/get_connected.py
+++ b/get_connected.py
@@ -1,14 +1,21 @@
 import requests
 import os
+import hashlib
 from dotenv import load_dotenv
 import json
 import gcal
-import model
-from datetime import datetime
+from datetime import datetime, timedelta
 import time
 import pytz
 from loguru import logger
-import model
+import checkin
+import db
+import sync
+
+# Note: the legacy `model.py` (pydantic v1 schemas) is no longer imported.
+# All ingestion now goes through db.py / sync.py which work directly on raw
+# dicts -- removing the pydantic v1 dep lets us use modern Python + FastAPI
+# without resolver conflicts.
 
 logger.add("debug.log", format="{time} {level} {message}", level='ERROR', retention="1 week", rotation="10 MB")
 load_dotenv()
@@ -90,7 +97,10 @@ class GalaxyAPI:
         shifts_dict = {}
         for response in responses:
             shift_id = response["shift"]["id"]
-            user = response["user"]
+            user = dict(response["user"])  # copy so we don't mutate the raw payload
+            # Carry the response_id on the user so hour_response_id can match
+            # back to this exact (user, shift) pair without ambiguity.
+            user["response_id"] = response.get("id")
             logger.debug(f'response: {response}')
             if shift_id in shifts_dict:
                 shifts_dict[shift_id]["users"].append(user)
@@ -108,68 +118,132 @@ class GalaxyAPI:
         return list(shifts_dict.values())
 
     def update_responses(self):
+        """Full refresh: pull /responses into SQLite, then push the resulting
+        per-shift roster to Google Calendar.
 
-        current_date = datetime.now().strftime('%Y-%m-%d')
-        # data = self.get_data_from_api(f'responses?since_updated={current_date}')
-        data = self.get_data_from_api('responses')
-        # response = model.ResponseObject.parse_obj(data[3])
-        # print(response)
-        # return data
-        tr = self.transform_responses(data)
-        # Save transformed responses to JSON file
-        with open('transformed_responses.json', 'w') as f:
+        The JSON file is still written as a debug snapshot so the legacy
+        diagnostics keep working, but SQLite is authoritative.
+        """
+        sync.sync_responses(self)
+
+        # Build the shift roster from SQLite for gcal. Same dict shape the
+        # gcal layer already expects (start_time / end_time / users / etc).
+        tr: list[dict] = []
+        with db.connect() as conn:
+            shifts = conn.execute(
+                """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
+                          s.need_id, n.title
+                   FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+                """,
+            ).fetchall()
+            for s in shifts:
+                signups = db.signups_for_shift(conn, s["id"])
+                users = []
+                for sg in signups:
+                    users.append({
+                        "id": sg["user_id"],
+                        "response_id": sg["response_id"],
+                        "user_fname": sg["fname"],
+                        "user_lname": sg["lname"],
+                        "user_email": sg["email"],
+                        "checkin_status": sg["classification"] or checkin.SIGNED_UP,
+                    })
+                tr.append({
+                    "id": s["id"],
+                    "start_time": datetime.strptime(s["start_ts"], "%Y-%m-%d %H:%M:%S"),
+                    "end_time": datetime.strptime(s["end_ts"], "%Y-%m-%d %H:%M:%S"),
+                    "need_id": s["need_id"],
+                    "duration": s["duration_min"],
+                    "slots": s["slots"],
+                    "title": s["title"],
+                    "users": users,
+                    "slots_filled": len(users),
+                })
+
+        with open("transformed_responses.json", "w") as f:
             json.dump(tr, f, default=str)
         gcal.get_calendars(gcal.service)
         gcal.update_calendar_events(tr, gcal.service, calendar_id=self.calendar_id, add_attendees=False)
-        logger.debug(f"updated_responses complete")
+        logger.debug("updated_responses complete")
 
     def user_checkin_update(self):
-        with open('transformed_responses.json', 'r') as f:
-            tr = json.load(f)
-        shifts_to_update = []
-        
+        """Incremental scan: pull /hours since cutoff, ingest into SQLite,
+        then push the per-shift delta to Google Calendar.
+
+        Returns the list of shift dicts that actually changed since the last
+        scan -- only those get sent to gcal (avoids rate-limit hammering).
+        """
+        shifts_to_update: list[dict] = []
+        tz = pytz.timezone("America/Chicago")
+        current_time = datetime.now(tz)
+        since = current_time - timedelta(hours=24)
+
         try:
-            # Get current date in YYYY-MM-DD format
-            current_date = datetime.now().strftime('%Y-%m-%d')
-            # Fetch all hours updated today in a single API call
-            hours_data = self.get_data_from_api('hours', {'since_updated': current_date})
-            
-            # Create a mapping of user IDs to their hour status
-            user_status_map = {}
-            if hours_data is not None:
-                for hour in hours_data:
-                    if 'user' in hour and 'id' in hour['user']:
-                        user_id = hour['user']['id']
-                        hour_status = hour.get('hour_status', '')
-                        # user_status_map[user_id] = hour_status
-                        user_status_map[user_id] = hour
-            
-            for shift in tr:
-                current_time = datetime.now(pytz.timezone('America/Chicago'))
-                shift_start = datetime.strptime(shift['start_time'], '%Y-%m-%d %H:%M:%S').replace(tzinfo=pytz.timezone('America/Chicago'))
-                time_diff = current_time - shift_start
-                if time_diff.total_seconds() <= 72000 and time_diff.total_seconds() >= -72000:
-                    shift_updated = False
-                    for user in shift['users']:
-                        # Check if user ID is in our map of updated statuses
-                        if user['id'] in user_status_map:
-                            user['status'] = user_status_map[user['id']]['hour_status']
-                            user['created_at'] = user_status_map[user['id']]['created_at']
-                            user['updated_at'] = user_status_map[user['id']]['updated_at']
-                            user['hour_source'] = user_status_map[user['id']]['hour_source']
-                            user['hours_id'] = user_status_map[user['id']]
-                            #Check if the user has checked in by comparing the created_at and updated_at
-                            if user['created_at'] == user['updated_at']:
-                                user['checkin_status'] = 'pending'
-                            else:
-                                user['checkin_status'] = 'approved'
-                            logger.debug(f"user: {user}")
-                            shift_updated = True
-                    
-                    # Only add shifts that had users with updated statuses
-                    if shift_updated:
-                        shifts_to_update.append(shift)
-            
+            sync.sync_hours(self, since=since)
+
+            with db.connect() as conn:
+                # Find shifts in the live-tracking window and rebuild their roster.
+                window_start = (current_time - timedelta(hours=20)).strftime("%Y-%m-%d %H:%M:%S")
+                window_end = (current_time + timedelta(hours=20)).strftime("%Y-%m-%d %H:%M:%S")
+                shifts = conn.execute(
+                    """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
+                              s.need_id, n.title
+                       FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+                       WHERE s.start_ts BETWEEN ? AND ?
+                    """,
+                    (window_start, window_end),
+                ).fetchall()
+
+                # Also write any newly-detected no_shows to history (idempotent).
+                conn.execute("BEGIN")
+                _ = sync.mark_no_shows(conn)
+                conn.execute("COMMIT")
+
+                for s in shifts:
+                    users = []
+                    for sg in db.signups_for_shift(conn, s["id"]):
+                        status = sync.current_status_for_signup(
+                            conn, sg["response_id"], sg["user_id"], s["end_ts"],
+                        )
+                        # Append to status_history if this is a transition.
+                        db.record_status(
+                            conn,
+                            response_id=sg["response_id"],
+                            shift_id=s["id"],
+                            user_id=sg["user_id"],
+                            status=status,
+                        )
+                        users.append({
+                            "id": sg["user_id"],
+                            "response_id": sg["response_id"],
+                            "user_fname": sg["fname"],
+                            "user_lname": sg["lname"],
+                            "user_email": sg["email"],
+                            "checkin_status": status,
+                        })
+                    # Fingerprint = sorted (response_id,status) pairs for the
+                    # shift. If unchanged since the last gcal push, skip --
+                    # this is what keeps us from spamming the Google Calendar
+                    # API every 60s for shifts that haven't moved.
+                    fp_input = ",".join(sorted(f"{u['response_id']}:{u['checkin_status']}" for u in users))
+                    fp = hashlib.sha1(fp_input.encode()).hexdigest()
+                    key = f"gcal_fp:{s['id']}"
+                    prev_fp = db.get_state(conn, key)
+                    if prev_fp == fp:
+                        continue
+                    db.set_state(conn, key, fp)
+                    shifts_to_update.append({
+                        "id": s["id"],
+                        "start_time": datetime.strptime(s["start_ts"], "%Y-%m-%d %H:%M:%S"),
+                        "end_time": datetime.strptime(s["end_ts"], "%Y-%m-%d %H:%M:%S"),
+                        "need_id": s["need_id"],
+                        "duration": s["duration_min"],
+                        "slots": s["slots"],
+                        "title": s["title"],
+                        "users": users,
+                        "slots_filled": len(users),
+                    })
+
             if len(shifts_to_update) > 0:
                 logger.debug(f"Updating {len(shifts_to_update)} shifts")
                 logger.debug(f"shifts_to_update: {shifts_to_update}")
@@ -188,31 +262,32 @@ class GalaxyAPI:
         return shifts_to_update
     
     def get_next_shift(self):
-        with open('transformed_responses.json', 'r') as f:
-            tr = json.load(f)
-        next_shift_time_diff = 0
-        for shift in tr:
-            current_time = datetime.now(pytz.timezone('America/Chicago'))
-            shift_start = datetime.strptime(shift['start_time'], '%Y-%m-%d %H:%M:%S').replace(tzinfo=pytz.timezone('America/Chicago'))
-            time_diff = current_time - shift_start
-            if time_diff.total_seconds() > next_shift_time_diff:
-                next_shift_time_diff = time_diff.total_seconds()
-                next_shift = shift
-        return next_shift_time_diff
-    
+        """Seconds until the next upcoming shift starts. inf if none."""
+        tz = pytz.timezone('America/Chicago')
+        now_ct = datetime.now(tz).strftime('%Y-%m-%d %H:%M:%S')
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT start_ts FROM shifts WHERE start_ts > ? ORDER BY start_ts ASC LIMIT 1",
+                (now_ct,),
+            ).fetchone()
+        if not row:
+            return float('inf')
+        start = tz.localize(datetime.strptime(row['start_ts'], '%Y-%m-%d %H:%M:%S'))
+        return (start - datetime.now(tz)).total_seconds()
+
     def get_last_shift(self):
-        with open('transformed_responses.json', 'r') as f:
-            tr = json.load(f)
-        #Larger than 10000 is a long time ago
-        last_shift_time_diff = 10000
-        for shift in tr:
-            current_time = datetime.now(pytz.timezone('America/Chicago'))
-            shift_start = datetime.strptime(shift['start_time'], '%Y-%m-%d %H:%M:%S').replace(tzinfo=pytz.timezone('America/Chicago'))
-            time_diff = shift_start - current_time
-            if 0 < time_diff.total_seconds() < last_shift_time_diff:
-                last_shift_time_diff = time_diff.total_seconds()
-                last_shift = shift
-        return last_shift_time_diff
+        """Seconds since the most recent shift ENDED. inf if none."""
+        tz = pytz.timezone('America/Chicago')
+        now_ct = datetime.now(tz).strftime('%Y-%m-%d %H:%M:%S')
+        with db.connect() as conn:
+            row = conn.execute(
+                "SELECT end_ts FROM shifts WHERE end_ts < ? ORDER BY end_ts DESC LIMIT 1",
+                (now_ct,),
+            ).fetchone()
+        if not row:
+            return float('inf')
+        end = tz.localize(datetime.strptime(row['end_ts'], '%Y-%m-%d %H:%M:%S'))
+        return (datetime.now(tz) - end).total_seconds()
             
 
     def get_user_list(self, api_key, offset=0, limit=50):
@@ -231,11 +306,10 @@ class GalaxyAPI:
         else:
             response.raise_for_status()  
 
-    def transform_objects(self, responce, model_class):
-        all_objects = []
-        for object in responce:
-            all_objects.append(model_class.parse_obj(object))
-        return all_objects
+    # transform_objects() lived here previously to coerce raw dicts into
+    # pydantic v1 ModelClass instances. Nothing called it in the active
+    # codebase, so it has been removed along with the `import model` to
+    # let us run on modern Python without pydantic v1's resolver headaches.
 # #TODO: sync with internal mongoDB
 # api_key = os.getenv('API_KEY')
 # email = os.getenv('EMAIL')

--- a/initial_ingest.py
+++ b/initial_ingest.py
@@ -1,0 +1,49 @@
+"""One-shot initial ingest -- run once after `./bootstrap.sh` to populate
+SQLite before launching the web viewer.
+
+Stubs the gcal module so this doesn't trigger a Google OAuth flow; only
+the SQLite store is touched. Safe to re-run; ingest is idempotent.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Block gcal's import-time OAuth side effect; we don't need calendar here.
+_fake = types.ModuleType("gcal")
+_fake.service = None
+_fake.get_calendars = lambda s: []
+_fake.update_calendar_events = lambda *a, **k: None
+sys.modules["gcal"] = _fake
+
+from loguru import logger
+
+import db
+import get_connected as gc
+import sync
+
+
+def main() -> None:
+    api = gc.GalaxyAPI()
+    db.init()
+    logger.info("ingesting /responses ...")
+    n_r = sync.sync_responses(api)
+    print(f"  {n_r} responses")
+    logger.info("ingesting /hours ...")
+    n_h = sync.sync_hours(api)
+    print(f"  {n_h} hours")
+    logger.info("marking historical no-shows ...")
+    with db.connect() as conn:
+        conn.execute("BEGIN")
+        n_ns = sync.mark_no_shows(conn)
+        conn.execute("COMMIT")
+    print(f"  {n_ns} no-show history rows backfilled")
+    print("done. now run: python run_web.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/preview_production_sync.py
+++ b/preview_production_sync.py
@@ -1,0 +1,166 @@
+"""Preview what the first sync to production would do.
+
+Compares the shifts currently in SQLite against what's actually on the
+production calendar (read-only) and prints a per-shift diff plan:
+
+  INSERT   shift_id  start  title    (no matching event on cal)
+  UPDATE   shift_id  start  title    (event exists, description/location/title differ)
+  NO-OP    shift_id  start  title    (event exists, content identical)
+  ORPHAN   event_id  start  title    (event on cal has no matching Galaxy shift)
+
+Reads the production CALENDAR_ID from .env. Does NOT write anything.
+
+Usage:
+    python preview_production_sync.py [--days N]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import checkin  # noqa: E402
+import db  # noqa: E402
+import gcal  # noqa: E402
+
+
+def build_expected_event(shift: dict) -> dict:
+    """Mirror what gcal.update_calendar_events would compose."""
+    lines = ["Signups:"]
+    for u in shift["users"]:
+        st = u.get("checkin_status") or checkin.SIGNED_UP
+        emoji = checkin.STATUS_EMOJI.get(st, "🔘")
+        lines.append(f"{emoji} {u.get('fname','')} {u.get('lname','')} "
+                     f"email: {u.get('email','')}")
+    description = "\n".join(lines) + "\n"
+    return {
+        "summary": f"{shift['title']} - ({shift['slots_filled']}/{shift['slots']}) ",
+        "location": shift.get("location") or "",
+        "description": description,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--days", type=int, default=14,
+                   help="how many days forward to inspect (default 14)")
+    args = p.parse_args()
+
+    cal_id = os.getenv("CALENDAR_ID")
+    if not cal_id:
+        print("CALENDAR_ID is not set in .env", file=sys.stderr)
+        return 1
+    print(f"-> production calendar id: ...{cal_id[-30:]}")
+    print(f"-> window: today + {args.days}d")
+    print(f"-> mode: READ ONLY -- nothing will be written.\n")
+
+    # Build what we would push.
+    now_ct = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    horizon = (datetime.now() + timedelta(days=args.days)).strftime("%Y-%m-%d %H:%M:%S")
+    expected: dict[str, dict] = {}
+    with db.connect() as conn:
+        shifts = conn.execute(
+            """SELECT s.id, s.start_ts, s.end_ts, s.slots, s.need_id,
+                      n.title, n.location
+               FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+               WHERE s.start_ts >= ? AND s.start_ts < ?
+               ORDER BY s.start_ts
+            """,
+            (now_ct, horizon),
+        ).fetchall()
+        for s in shifts:
+            sgs = db.signups_for_shift(conn, s["id"])
+            users = []
+            for sg in sgs:
+                users.append({
+                    "fname": sg["fname"], "lname": sg["lname"], "email": sg["email"],
+                    "response_id": sg["response_id"],
+                    "checkin_status": sg["classification"] or checkin.SIGNED_UP,
+                })
+            expected[s["id"]] = {
+                "id": s["id"],
+                "start": s["start_ts"],
+                "title": s["title"],
+                "slots": s["slots"],
+                "slots_filled": len(users),
+                "location": s["location"],
+                "users": users,
+            }
+
+    # Pull existing calendar events in the same window.
+    svc = gcal.get_service()
+    time_min = datetime.now().isoformat() + "Z"
+    time_max = (datetime.now() + timedelta(days=args.days)).isoformat() + "Z"
+    actual: dict[str, dict] = {}
+    page_token = None
+    while True:
+        resp = svc.events().list(
+            calendarId=cal_id, maxResults=2500,
+            timeMin=time_min, timeMax=time_max,
+            singleEvents=True, pageToken=page_token,
+        ).execute()
+        for e in resp.get("items", []):
+            actual[e["id"]] = e
+        page_token = resp.get("nextPageToken")
+        if not page_token:
+            break
+
+    inserts, updates, noops, orphans = [], [], [], []
+    for sid, shift in expected.items():
+        ev = actual.get(sid)
+        if ev is None:
+            inserts.append(shift)
+            continue
+        want = build_expected_event(shift)
+        diffs = []
+        if (ev.get("summary") or "") != want["summary"]:
+            diffs.append("summary")
+        if (ev.get("location") or "") != want["location"]:
+            diffs.append("location")
+        if (ev.get("description") or "") != want["description"]:
+            diffs.append("description")
+        if diffs:
+            updates.append((shift, diffs))
+        else:
+            noops.append(shift)
+
+    for eid, ev in actual.items():
+        if eid not in expected:
+            orphans.append(ev)
+
+    def _fmt(s):
+        return f"{s['start'][:16]}  ({s['slots_filled']}/{s['slots']})  {(s['title'] or '')[:50]}"
+
+    print(f"=== INSERT ({len(inserts)}) -- shifts that would be created ===")
+    for s in inserts:
+        print(f"  + {_fmt(s)}")
+    print()
+    print(f"=== UPDATE ({len(updates)}) -- existing events that would be rewritten ===")
+    for s, diffs in updates:
+        print(f"  ~ {_fmt(s)}    [{','.join(diffs)}]")
+    print()
+    print(f"=== NO-OP ({len(noops)}) -- already up to date ===")
+    for s in noops[:10]:
+        print(f"    {_fmt(s)}")
+    if len(noops) > 10:
+        print(f"    ... and {len(noops) - 10} more")
+    print()
+    print(f"=== ORPHANS ({len(orphans)}) -- on the cal but no matching Galaxy shift ===")
+    for ev in orphans[:10]:
+        start = ((ev.get("start") or {}).get("dateTime") or "")[:16]
+        print(f"  ? id={ev['id']:>20}  {start}  {ev.get('summary','')[:50]}")
+    if len(orphans) > 10:
+        print(f"  ? ... and {len(orphans) - 10} more  (these stay untouched)")
+    print()
+    print(f"Summary: {len(inserts)} inserts + {len(updates)} updates + "
+          f"{len(noops)} no-ops + {len(orphans)} orphans (left alone)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/push_to_demo.py
+++ b/push_to_demo.py
@@ -1,0 +1,123 @@
+"""One-shot push of upcoming shifts to a test calendar.
+
+Pulls /needs, /responses, and /hours from Galaxy Digital into SQLite,
+then pushes the next N days of shifts (default 14) to whichever calendar
+id is in GCAL_TEST_CALENDAR_ID -- so production stays untouched.
+
+Why not just call api.update_responses()? That pushes the entire all-
+time shift list (~1465 events for this org), which is overkill for a
+verification run and chews through Google Calendar quota.
+
+Usage:
+    GCAL_TEST_CALENDAR_ID="<id>" python push_to_demo.py [--days 14]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import checkin  # noqa: E402
+import db  # noqa: E402
+import gcal  # noqa: E402
+import get_connected as gc  # noqa: E402
+import sync  # noqa: E402
+
+
+def upcoming_shifts(conn, days: int) -> list[dict]:
+    """Build shift dicts for the next `days` days in the shape gcal expects."""
+    horizon = (datetime.now() + timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    now_ct = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    rows = conn.execute(
+        """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
+                  s.need_id, n.title, n.location
+           FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+           WHERE s.start_ts >= ? AND s.start_ts < ?
+           ORDER BY s.start_ts
+        """,
+        (now_ct, horizon),
+    ).fetchall()
+
+    out = []
+    for s in rows:
+        users = []
+        for sg in db.signups_for_shift(conn, s["id"]):
+            users.append({
+                "id": sg["user_id"],
+                "response_id": sg["response_id"],
+                "user_fname": sg["fname"],
+                "user_lname": sg["lname"],
+                "user_email": sg["email"],
+                "checkin_status": sg["classification"] or checkin.SIGNED_UP,
+            })
+        out.append({
+            "id": s["id"],
+            "start_time": datetime.strptime(s["start_ts"], "%Y-%m-%d %H:%M:%S"),
+            "end_time": datetime.strptime(s["end_ts"], "%Y-%m-%d %H:%M:%S"),
+            "need_id": s["need_id"],
+            "duration": s["duration_min"],
+            "slots": s["slots"],
+            "title": s["title"] or "(no title)",
+            "location": s["location"],
+            "users": users,
+            "slots_filled": len(users),
+        })
+    return out
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--days", type=int, default=14,
+                   help="how many days of upcoming shifts to push (default 14)")
+    args = p.parse_args()
+
+    demo_cal = os.getenv("GCAL_TEST_CALENDAR_ID")
+    if not demo_cal:
+        print("Set GCAL_TEST_CALENDAR_ID before running (won't touch production).",
+              file=sys.stderr)
+        return 1
+    print(f"-> using calendar id: ...{demo_cal[-30:]}")
+
+    api = gc.GalaxyAPI()
+    print("\n[1/3] sync_responses (incl. sync_needs + mark_no_shows) ...")
+    n_resp = sync.sync_responses(api)
+    print(f"     {n_resp} responses ingested")
+
+    print("\n[2/3] sync_hours (24h) ...")
+    n_hours = sync.sync_hours(api)
+    print(f"     {n_hours} hours ingested")
+
+    with db.connect() as conn:
+        shifts = upcoming_shifts(conn, args.days)
+    print(f"\n[3/3] pushing {len(shifts)} shifts (next {args.days}d) to gcal ...")
+    if not shifts:
+        print("     nothing to push.")
+        return 0
+
+    svc = gcal.get_service()
+    gcal.update_calendar_events(shifts, svc, calendar_id=demo_cal, add_attendees=False)
+
+    print(f"\n=== summary ===")
+    for s in shifts:
+        loc = s["location"] or "(no location)"
+        statuses = {}
+        for u in s["users"]:
+            st = u["checkin_status"]
+            statuses[st] = statuses.get(st, 0) + 1
+        status_bar = " ".join(f"{checkin.STATUS_EMOJI[k]}{v}"
+                              for k, v in statuses.items()
+                              if k in checkin.STATUS_EMOJI)
+        print(f"  {s['start_time'].strftime('%Y-%m-%d %H:%M')}  "
+              f"({s['slots_filled']}/{s['slots']})  {s['title']}")
+        print(f"      @ {loc}   [{status_bar}]")
+    print("\nOpen Google Calendar -> RangersTest to verify.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,63 @@
-# to run
+# quick start
 
-`source env/bin/activate`
-`python run_cal_update`
+```bash
+./bootstrap.sh                     # creates env/, installs deps (one-time)
+source env/bin/activate
+cp .env.example .env               # then fill in API_KEY, EMAIL, PASSWORD, etc.
+
+python verify_galaxy_creds.py      # smoke-test API credentials
+python run_cal_update.py           # sync loop + digest scheduler
+python run_web.py                  # live web viewer (separate process)
+python -m digest --dry-run         # render the digest to stdout
+```
+
+If you skip `bootstrap.sh` and `python3 -m venv env` was never run, the
+README's old `source env/bin/activate` will fail with "no such file or
+directory" -- that's why the bootstrap script exists.
 
 # Galaxy Digital Google Calendar Sync
 
-This project synchronizes events from Galaxy Digital to a Google Calendar. It automates the process of updating your Google Calendar with events managed in Galaxy Digital, ensuring that your calendar stays up-to-date without manual intervention.
+This project synchronizes events from Galaxy Digital to a Google Calendar.
+It also:
+
+- Tracks live check-in / check-out state per volunteer (kiosk-source
+  detection -- `hour_status` and `hour_date_end` are not reliable signals).
+- Stores everything in a local SQLite database (`galaxy_sync.sqlite3`) so
+  the calendar push, email digest, and web page all share one source of
+  truth.
+- Sends a daily HTML email digest (signed up / checked in / checked out /
+  no-show + repeat-offender table). Schedule and recipient configurable in
+  `.env`.
+- Exposes a local FastAPI page (default `http://127.0.0.1:8765`) for
+  real-time monitoring during shifts.
+
+## Architecture
+
+```
+              ┌──────────────────┐
+              │ Galaxy Digital   │
+              │   /responses     │
+              │   /hours         │
+              └────────┬─────────┘
+                       │ poll
+                       ▼
+   ┌────────────────────────────────────┐
+   │ sync.py   (ingest)                 │
+   │   ↳ checkin.py  (classify hours)   │
+   │   ↳ db.py       (SQLite I/O)       │
+   └────┬───────────────┬───────────────┘
+        │ shifts        │ status_history
+        ▼               ▼
+   ┌────────┐      ┌──────────┐      ┌──────────┐
+   │ gcal.py│      │ digest.py│      │ web.py   │
+   │  push  │      │  email   │      │  FastAPI │
+   └────────┘      └──────────┘      └──────────┘
+```
+
+`run_cal_update.py` drives the sync loop (2h full refresh, 60s scan when a
+shift is within ±1h, idle sleep otherwise) and fires the digest when the
+configured schedule (`DIGEST_SCHEDULE=daily@21:00` etc.) crosses a
+boundary. The web app reads the SQLite DB independently.
 
 ## Table of Contents
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,24 @@
-cachetools==5.3.1
-certifi==2023.5.7
-charset-normalizer==3.1.0
-dnspython==2.3.0
-email-validator==2.0.0.post2
-google-api-core==2.11.0
-google-api-python-client==2.88.0
-google-auth==2.19.1
-google-auth-httplib2==0.1.0
-google-auth-oauthlib==1.0.0
-googleapis-common-protos==1.59.0
-httplib2==0.22.0
-idna==3.4
-loguru==0.7.0
-oauthlib==3.2.2
-protobuf==4.23.2
-pyasn1==0.5.0
-pyasn1-modules==0.3.0
-pydantic==1.10.9
-pyparsing==3.0.9
-python-dotenv==1.0.0
-pytz==2023.3
-requests==2.31.0
-requests-oauthlib==1.3.1
-rsa==4.9
-six==1.16.0
-typing_extensions==4.6.3
-uritemplate==4.1.1
-urllib3==1.26.16
+# Loose constraints so this installs cleanly on Python 3.11 through 3.14.
+# Previous file had hard-pinned 2023-era versions that pip's resolver
+# could no longer satisfy together.
+
+requests>=2.31
+python-dotenv>=1.0
+pytz>=2023.3
+loguru>=0.7
+
+# Google Calendar
+google-api-python-client>=2.100
+google-auth>=2.23
+google-auth-httplib2>=0.2
+google-auth-oauthlib>=1.1
+
+# Web viewer
+fastapi>=0.110
+uvicorn[standard]>=0.27
+
+# model.py uses pydantic v1, but nothing in the active code path imports it
+# anymore. Leaving it unpinned -- if you later remove or migrate model.py,
+# delete this line too.
+pydantic
+email-validator

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ uvicorn[standard]>=0.27
 # delete this line too.
 pydantic
 email-validator
+
+# Dev / test
+pytest>=7

--- a/run_cal_update.py
+++ b/run_cal_update.py
@@ -1,16 +1,85 @@
 import get_connected as gc
 import gcal
-import model
 import importlib
 import time
 from loguru import logger
 import os
+from datetime import datetime
+import pytz
 from dotenv import load_dotenv
 import requests
 import json
 
+import db
+import digest as digest_mod
+
 load_dotenv()
 WEBHOOK_URL = os.getenv('WEBHOOK_URL')
+CHICAGO = pytz.timezone('America/Chicago')
+
+# Digest schedule: cron-light. Examples:
+#   DIGEST_SCHEDULE=daily@21:00      every day at 9pm CT
+#   DIGEST_SCHEDULE=hourly           every hour at :00
+#   DIGEST_SCHEDULE=off              never
+DIGEST_SCHEDULE = os.getenv('DIGEST_SCHEDULE', 'daily@21:00')
+
+
+def _digest_due(now_ct: datetime, last_sent_iso: str | None) -> bool:
+    """Decide whether the current tick should fire the digest. Returns True
+    if we've crossed the scheduled boundary since `last_sent_iso`.
+    """
+    sched = (DIGEST_SCHEDULE or '').lower().strip()
+    if sched in ('off', 'never', ''):
+        return False
+    last_sent = None
+    if last_sent_iso:
+        try:
+            last_sent = datetime.fromisoformat(last_sent_iso)
+        except ValueError:
+            last_sent = None
+    if sched == 'hourly':
+        boundary = now_ct.replace(minute=0, second=0, microsecond=0)
+    elif sched.startswith('daily@'):
+        try:
+            hh, mm = map(int, sched.split('@', 1)[1].split(':'))
+        except (ValueError, IndexError):
+            hh, mm = 21, 0
+        boundary = now_ct.replace(hour=hh, minute=mm, second=0, microsecond=0)
+        if now_ct < boundary:
+            return False
+    else:
+        return False
+    if last_sent is None:
+        return now_ct >= boundary
+    # Convert last_sent (UTC iso) to CT for comparison.
+    if last_sent.tzinfo is None:
+        last_sent = pytz.UTC.localize(last_sent).astimezone(CHICAGO)
+    else:
+        last_sent = last_sent.astimezone(CHICAGO)
+    return last_sent < boundary <= now_ct
+
+
+def maybe_send_digest():
+    """Fire the digest if we've crossed a schedule boundary. No-op otherwise."""
+    db.init()
+    with db.connect() as conn:
+        last_sent_iso = db.get_state(conn, 'last_digest_sent_at')
+    if not _digest_due(datetime.now(CHICAGO), last_sent_iso):
+        return
+    try:
+        data = digest_mod.collect(days_back=int(os.getenv('DIGEST_LOOKBACK_DAYS', '1')))
+        html = digest_mod.render_html(data)
+        text = digest_mod.render_text(data)
+        ok = digest_mod.send(data, html, text)
+        if ok:
+            with db.connect() as conn:
+                db.set_state(conn, 'last_digest_sent_at',
+                             datetime.utcnow().isoformat(timespec='seconds'))
+            logger.info('digest sent')
+        else:
+            logger.info('digest skipped (missing DIGEST_EMAIL_TO or SMTP_HOST)')
+    except Exception as e:
+        logger.error(f'digest failed: {e}')
 
 def post_to_slack( message):
     headers = {'Content-Type': 'application/json'}
@@ -24,36 +93,51 @@ def post_to_slack( message):
     return response
 
 def update_cal():
+    """Main loop.
+
+    Cadence:
+      - Full /responses refresh every 2 hours (REFRESH_INTERVAL_S).
+      - Check-in scan every 60s when a shift is happening soon, just ended,
+        or is currently in progress (window: -1h .. +1h of a shift boundary).
+      - Otherwise sleep 5 minutes between idle ticks.
+
+    Both helpers are now corrected:
+      - get_next_shift() -> seconds UNTIL next start (inf if none)
+      - get_last_shift() -> seconds SINCE last end       (inf if none)
+    """
+    REFRESH_INTERVAL_S = 2 * 3600
+    SCAN_HOT_WINDOW_S = 3600
     fail_count = 0
-    last_update = 0
-    next_shift_time_diff = 0
-    last_shift_time_diff = 0
+    last_refresh = 0.0
     while True:
         try:
             gcc = gc.GalaxyAPI()
-            if time.time() - last_update > 3600:
+            now = time.time()
+            if now - last_refresh > REFRESH_INTERVAL_S:
                 gcc.update_responses()
-                last_update = time.time()
-                logger.debug("Updated responses")
-                time.sleep(100)
-            next_shift_time_diff = gcc.get_next_shift()
-            # if next_shift_time_diff < 3600:
-            #     gcc.user_checkin_update()
-            #     logger.debug("Updated checkin")
-            # logger.debug(f"Next shift time diff: {next_shift_time_diff}")
-            # if next_shift_time_diff > 3600:
-            #     last_update = time.time()
-            last_shift_time_diff = gcc.get_last_shift()
-            if last_shift_time_diff < 3600:
-                gcc.user_checkin_update()
-                logger.debug("Updated checkin")
-            time.sleep(300)
+                last_refresh = now
+                logger.debug("Full /responses refresh complete")
+
+            next_in = gcc.get_next_shift()    # seconds until next start
+            since_last = gcc.get_last_shift()  # seconds since last end
+            hot = (next_in < SCAN_HOT_WINDOW_S) or (since_last < SCAN_HOT_WINDOW_S)
+
+            if hot:
+                changed = gcc.user_checkin_update()
+                logger.debug(f"Scan tick: pushed {len(changed) if changed else 0} shift updates")
+                maybe_send_digest()
+                time.sleep(60)
+            else:
+                logger.debug(f"Idle: next shift in {next_in:.0f}s, last ended {since_last:.0f}s ago")
+                maybe_send_digest()
+                time.sleep(300)
+
             importlib.reload(gc)
             importlib.reload(gcal)
+            fail_count = 0
         except Exception as e:
             fail_count += 1
             logger.error(f"failed: {fail_count}. {e}")
             post_to_slack(f"Galaxy_gcal_sync \n failed: {fail_count} sleeptime:{fail_count*60}.\n {e}")
             time.sleep(fail_count * 60)
-            pass
 update_cal()

--- a/run_cal_update.py
+++ b/run_cal_update.py
@@ -4,7 +4,7 @@ import importlib
 import time
 from loguru import logger
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 import pytz
 from dotenv import load_dotenv
 import requests
@@ -74,7 +74,7 @@ def maybe_send_digest():
         if ok:
             with db.connect() as conn:
                 db.set_state(conn, 'last_digest_sent_at',
-                             datetime.utcnow().isoformat(timespec='seconds'))
+                             datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec='seconds'))
             logger.info('digest sent')
         else:
             logger.info('digest skipped (missing DIGEST_EMAIL_TO or SMTP_HOST)')

--- a/run_demo_stack.sh
+++ b/run_demo_stack.sh
@@ -46,18 +46,30 @@ SYNC_PID=$!
 python run_web.py        >"$LOG_WEB"  2>&1 &
 WEB_PID=$!
 
+# Live-tail both logs prefixed by source, so you can watch the dance.
+( tail -F "$LOG_SYNC" | sed 's/^/[sync] /' ) &
+TAIL_SYNC_PID=$!
+( tail -F "$LOG_WEB"  | sed 's/^/[web]  /' ) &
+TAIL_WEB_PID=$!
+
 cleanup() {
+  # Idempotent: trap fires for both INT and EXIT; bail on the second.
+  [ -n "${_CLEANUP_DONE:-}" ] && return
+  _CLEANUP_DONE=1
   echo
-  echo ">> stopping (sync=$SYNC_PID web=$WEB_PID)"
+  echo ">> stopping (sync=$SYNC_PID web=$WEB_PID tails=$TAIL_SYNC_PID,$TAIL_WEB_PID)"
+  # Kill the tails first so `wait` below doesn't hang on them
+  # (tail -F never exits on its own).
+  kill "$TAIL_SYNC_PID" "$TAIL_WEB_PID" 2>/dev/null
   kill "$SYNC_PID" "$WEB_PID" 2>/dev/null
-  wait 2>/dev/null
+  # Give them a moment to clean up; then SIGKILL anything still alive.
+  sleep 1
+  kill -9 "$SYNC_PID" "$WEB_PID" "$TAIL_SYNC_PID" "$TAIL_WEB_PID" 2>/dev/null
   echo ">> done."
 }
 trap cleanup EXIT INT TERM
 
-# Live-tail both logs prefixed by source, so you can watch the dance.
-( tail -F "$LOG_SYNC" | sed 's/^/[sync] /' ) &
-( tail -F "$LOG_WEB"  | sed 's/^/[web]  /' ) &
-
-# Block on the sync loop -- if it exits we shut everything down.
+# Block on the sync loop -- if it exits we shut everything down. Wait
+# only on the specific PID, NOT bare `wait`, otherwise we also wait for
+# the tail -F children which never terminate on their own.
 wait "$SYNC_PID"

--- a/run_demo_stack.sh
+++ b/run_demo_stack.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Soak-test the full stack against the RangersTest demo calendar.
+#
+# Run this in one terminal -- it brings up:
+#   - run_cal_update.py  (sync loop: 2h refresh, 60s scan in hot window)
+#   - run_web.py         (live FastAPI page on :8765 with SSE)
+#
+# Both processes inherit CALENDAR_ID from this script's env, so the
+# production calendar in .env stays untouched. Send SIGINT (Ctrl-C) to
+# stop everything; the trap below kills both children.
+#
+# Required first time:  ./bootstrap.sh && source env/bin/activate
+# Required always:      WEB_PASSWORD set in .env (the web viewer
+#                       refuses to serve otherwise).
+
+set -uo pipefail
+cd "$(dirname "$0")"
+
+DEMO_CAL='c_92420fb59cb6fcf9ed6753e7224ce02ee704ffee45de20039137fac50c6ac452@group.calendar.google.com'
+export CALENDAR_ID="$DEMO_CAL"
+# Same SQLite file as prod; the data layer is shared, only the gcal
+# push target differs. If you want full isolation use GALAXY_DB_PATH.
+# export GALAXY_DB_PATH="galaxy_demo.sqlite3"
+
+if [ ! -d env ]; then
+  echo "ERR: env/ not present. Run ./bootstrap.sh first." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source env/bin/activate
+
+mkdir -p logs
+LOG_SYNC="logs/sync.log"
+LOG_WEB="logs/web.log"
+: > "$LOG_SYNC"
+: > "$LOG_WEB"
+
+echo ">> calendar target: ...${DEMO_CAL: -30}"
+echo ">> tailing logs:    $LOG_SYNC and $LOG_WEB"
+echo ">> web viewer at:   http://127.0.0.1:${WEB_PORT:-8765}"
+echo
+
+python run_cal_update.py >"$LOG_SYNC" 2>&1 &
+SYNC_PID=$!
+python run_web.py        >"$LOG_WEB"  2>&1 &
+WEB_PID=$!
+
+cleanup() {
+  echo
+  echo ">> stopping (sync=$SYNC_PID web=$WEB_PID)"
+  kill "$SYNC_PID" "$WEB_PID" 2>/dev/null
+  wait 2>/dev/null
+  echo ">> done."
+}
+trap cleanup EXIT INT TERM
+
+# Live-tail both logs prefixed by source, so you can watch the dance.
+( tail -F "$LOG_SYNC" | sed 's/^/[sync] /' ) &
+( tail -F "$LOG_WEB"  | sed 's/^/[web]  /' ) &
+
+# Block on the sync loop -- if it exits we shut everything down.
+wait "$SYNC_PID"

--- a/run_web.py
+++ b/run_web.py
@@ -1,0 +1,28 @@
+"""Launch the web viewer locally.
+
+Reads:
+  WEB_PASSWORD   required, else web.py returns 503 on every request.
+  WEB_USERNAME   default 'volunteer'
+  WEB_HOST       default '127.0.0.1' (bind to localhost only)
+  WEB_PORT       default 8765
+  GALAXY_DB_PATH default 'galaxy_sync.sqlite3'
+
+Run: python run_web.py
+"""
+import os
+import uvicorn
+from dotenv import load_dotenv
+
+load_dotenv()
+
+if __name__ == "__main__":
+    if not os.getenv("WEB_PASSWORD"):
+        print("WARNING: WEB_PASSWORD is not set; the server will refuse all "
+              "requests with HTTP 503. Set WEB_PASSWORD in .env before "
+              "exposing the page.")
+    uvicorn.run(
+        "web:app",
+        host=os.getenv("WEB_HOST", "127.0.0.1"),
+        port=int(os.getenv("WEB_PORT", "8765")),
+        log_level=os.getenv("WEB_LOG_LEVEL", "info"),
+    )

--- a/setup_galaxy_sync_service.sh
+++ b/setup_galaxy_sync_service.sh
@@ -1,38 +1,120 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Install systemd units that run the sync loop and web viewer on boot.
+#
+# Two units get created:
+#   galaxy_sync.service   -- runs run_cal_update.py forever
+#   galaxy_web.service    -- runs run_web.py (FastAPI on 127.0.0.1:8765)
+#
+# Each one:
+#   - Lives under /etc/systemd/system/
+#   - Starts after the network is up
+#   - Restarts on crash with a 5s backoff
+#   - Reads its env from $WORKING_DIR/.env (so secrets stay out of the unit)
+#   - Runs as $USER:$GROUP (customize below)
+#
+# Run with sudo:
+#     sudo ./setup_galaxy_sync_service.sh
+#
+# Override paths / user via env if your layout differs:
+#     WORKING_DIR=/opt/galaxy USER=galaxy sudo -E ./setup_galaxy_sync_service.sh
 
-SERVICE_NAME="galaxy_sync.service"
-WORKING_DIR="/home/debmin/galaxy_digital_gcal_sync"
-VENV_DIR="$WORKING_DIR/env"
-EXEC_CMD="python run_cal_update.py"
-USER="debmin"
-GROUP="debmin"
+set -euo pipefail
 
-# Create the service file
-sudo bash -c "cat <<EOT > /etc/systemd/system/$SERVICE_NAME
+SYNC_SERVICE="${SYNC_SERVICE:-galaxy_sync.service}"
+WEB_SERVICE="${WEB_SERVICE:-galaxy_web.service}"
+WORKING_DIR="${WORKING_DIR:-/home/debmin/galaxy_digital_gcal_sync}"
+VENV_DIR="${VENV_DIR:-$WORKING_DIR/env}"
+USER_NAME="${USER:-debmin}"
+GROUP_NAME="${GROUP:-debmin}"
+ENV_FILE="${ENV_FILE:-$WORKING_DIR/.env}"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "this script must be run as root (try: sudo $0)" >&2
+  exit 1
+fi
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+  echo "no venv at $VENV_DIR -- run ./bootstrap.sh first." >&2
+  exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "no .env at $ENV_FILE -- copy .env.example and fill it in." >&2
+  exit 1
+fi
+
+# --- galaxy_sync.service ---------------------------------------------------
+cat <<EOT > /etc/systemd/system/$SYNC_SERVICE
 [Unit]
-Description=Galaxy Digital Google Calendar Sync
-After=network.target
+Description=Galaxy Digital -> Google Calendar sync loop
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+Type=simple
 WorkingDirectory=$WORKING_DIR
-ExecStart=$VENV_DIR/bin/$EXEC_CMD
-Environment=\"PATH=$VENV_DIR/bin\"
+EnvironmentFile=$ENV_FILE
+ExecStart=$VENV_DIR/bin/python $WORKING_DIR/run_cal_update.py
 Restart=always
-User=$USER
-Group=$GROUP
+RestartSec=5
+User=$USER_NAME
+Group=$GROUP_NAME
+# loguru writes to debug.log inside WorkingDirectory; this also pipes
+# stdout/stderr to journald so 'journalctl -u $SYNC_SERVICE -f' works.
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
-EOT"
+EOT
 
-# Reload systemd daemon to apply the new service
-sudo systemctl daemon-reload
+# --- galaxy_web.service ----------------------------------------------------
+cat <<EOT > /etc/systemd/system/$WEB_SERVICE
+[Unit]
+Description=Galaxy Digital live web viewer (FastAPI/uvicorn)
+After=network-online.target $SYNC_SERVICE
+Wants=network-online.target
 
-# Enable the service to start on boot
-sudo systemctl enable $SERVICE_NAME
+[Service]
+Type=simple
+WorkingDirectory=$WORKING_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=$VENV_DIR/bin/python $WORKING_DIR/run_web.py
+Restart=always
+RestartSec=5
+User=$USER_NAME
+Group=$GROUP_NAME
+StandardOutput=journal
+StandardError=journal
 
-# Start the service immediately
-sudo systemctl start $SERVICE_NAME
+[Install]
+WantedBy=multi-user.target
+EOT
 
-# Check the status of the service
-sudo systemctl status $SERVICE_NAME
+systemctl daemon-reload
+systemctl enable "$SYNC_SERVICE" "$WEB_SERVICE"
+systemctl restart "$SYNC_SERVICE" "$WEB_SERVICE"
+
+echo
+echo ">> installed and started:"
+systemctl --no-pager --lines=4 status "$SYNC_SERVICE" || true
+echo
+systemctl --no-pager --lines=4 status "$WEB_SERVICE" || true
+echo
+cat <<TIPS
+
+Management:
+  sudo systemctl status   $SYNC_SERVICE $WEB_SERVICE
+  sudo systemctl restart  $SYNC_SERVICE
+  sudo systemctl stop     $SYNC_SERVICE $WEB_SERVICE
+  sudo systemctl disable  $SYNC_SERVICE $WEB_SERVICE   # stop autostart
+
+Logs:
+  sudo journalctl -u $SYNC_SERVICE -f
+  sudo journalctl -u $WEB_SERVICE  -f
+  tail -F $WORKING_DIR/debug.log
+
+Web viewer:
+  http://127.0.0.1:\${WEB_PORT:-8765}
+  (set WEB_PASSWORD in .env first or every request returns 503)
+TIPS

--- a/simulate_checkin.py
+++ b/simulate_checkin.py
@@ -1,0 +1,165 @@
+"""Forge a kiosk check-in / check-out locally for soak-testing.
+
+This writes a synthetic hours row directly into SQLite. It does NOT
+touch the Galaxy Digital API -- the next sync_hours() run would
+overwrite anything you fake here, but in the meantime the gcal pusher
+and the web viewer will both react as if a real volunteer just walked
+up to the kiosk.
+
+Usage:
+    # List today's signups so you can pick a response_id
+    python simulate_checkin.py list
+
+    # Mark someone checked-in (yellow dot)
+    python simulate_checkin.py in  <response_id>
+
+    # Mark them checked-out (green dot)
+    python simulate_checkin.py out <response_id>
+
+    # Clear the simulated record (revert to signed_up)
+    python simulate_checkin.py clear <response_id>
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from datetime import datetime
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import checkin
+import db
+
+
+def _now() -> str:
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def cmd_list(_args):
+    db.init()
+    with db.connect() as conn:
+        rows = conn.execute(
+            """SELECT sg.id AS rid, u.fname, u.lname, u.email,
+                      s.id AS sid, s.start_ts, n.title,
+                      h.classification
+               FROM signups sg
+               JOIN users u  ON u.id = sg.user_id
+               JOIN shifts s ON s.id = sg.shift_id
+               LEFT JOIN needs n ON n.id = s.need_id
+               LEFT JOIN hours h ON h.response_id = sg.id
+               WHERE date(s.start_ts) = date('now','localtime')
+               ORDER BY s.start_ts, u.lname
+            """,
+        ).fetchall()
+    if not rows:
+        print("no signups for today")
+        return
+    print(f"{'response_id':>12}  {'shift_start':16}  {'status':14}  who")
+    print("-" * 90)
+    for r in rows:
+        st = r["classification"] or checkin.SIGNED_UP
+        emoji = checkin.STATUS_EMOJI.get(st, "?")
+        print(f"{r['rid']:>12}  {r['start_ts'][:16]}  {emoji} {st:12}  "
+              f"{r['fname']} {r['lname']}  {(r['title'] or '')[:40]}")
+
+
+def _write_hour(rid: str, source: str) -> None:
+    db.init()
+    with db.connect() as conn:
+        sg = conn.execute(
+            "SELECT sg.user_id, sg.shift_id, sg.need_id "
+            "FROM signups sg WHERE sg.id = ?", (rid,)
+        ).fetchone()
+        if not sg:
+            print(f"no signup with response_id={rid}", file=sys.stderr)
+            sys.exit(1)
+        # Use a synthetic id that won't collide with real /hours rows
+        # (real ids are numeric strings; ours starts with "sim-").
+        hid = f"sim-{uuid.uuid4().hex[:10]}"
+        conn.execute("BEGIN")
+        # Idempotent: if a simulated row already exists for this rid,
+        # update it rather than insert a second one.
+        existing = conn.execute(
+            "SELECT id FROM hours WHERE response_id = ? AND id LIKE 'sim-%' LIMIT 1",
+            (rid,)
+        ).fetchone()
+        if existing:
+            hid = existing["id"]
+            classification = checkin.classify_hour(checkin.HourSignal.from_api({
+                "hour_response_id": rid,
+                "hour_source": source,
+                "user": {"id": sg["user_id"]},
+            }))
+            conn.execute(
+                "UPDATE hours SET source=?, classification=?, updated_at=? WHERE id=?",
+                (source, classification, _now(), hid),
+            )
+        else:
+            db.ingest_hour(conn, {
+                "id": hid,
+                "hour_response_id": rid,
+                "user": {"id": sg["user_id"]},
+                "need": {"id": sg["need_id"]},
+                "hour_source": source,
+                "hour_status": "approved",
+                "hour_date_start": _now(),
+                "hour_date_end": _now(),
+                "created_at": _now(),
+                "updated_at": _now(),
+            })
+        # Also stamp the gcal fingerprint key so the next user_checkin_update
+        # tick will actually push -- without this the sync loop would compute
+        # the same fingerprint it had cached and skip.
+        conn.execute(
+            "DELETE FROM scan_state WHERE key = ?",
+            (f"gcal_fp:{sg['shift_id']}",),
+        )
+        conn.execute("COMMIT")
+    print(f"wrote simulated hour {hid} for response_id={rid}")
+    print("  source:", source)
+    print("  Next sync tick (~60s in hot window) will push the change.")
+
+
+def cmd_in(args):
+    _write_hour(args.response_id,
+                "Added at: /kiosk/storeCheckin/ by simulate_checkin.py")
+
+
+def cmd_out(args):
+    _write_hour(args.response_id,
+                "Added at: /kiosk/storeCheckin/ by simulate_checkin.py "
+                "Updated at: /kiosk/storeCheckout/ by simulate_checkin.py")
+
+
+def cmd_clear(args):
+    db.init()
+    with db.connect() as conn:
+        n = conn.execute(
+            "DELETE FROM hours WHERE response_id = ? AND id LIKE 'sim-%'",
+            (args.response_id,),
+        ).rowcount
+        # Force a gcal repush.
+        sg = conn.execute("SELECT shift_id FROM signups WHERE id=?",
+                          (args.response_id,)).fetchone()
+        if sg:
+            conn.execute("DELETE FROM scan_state WHERE key=?",
+                         (f"gcal_fp:{sg['shift_id']}",))
+    print(f"cleared {n} simulated hour(s) for response_id={args.response_id}")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list")
+    pi = sub.add_parser("in");   pi.add_argument("response_id")
+    po = sub.add_parser("out");  po.add_argument("response_id")
+    pc = sub.add_parser("clear"); pc.add_argument("response_id")
+    args = p.parse_args()
+    {"list": cmd_list, "in": cmd_in, "out": cmd_out, "clear": cmd_clear}[args.cmd](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/sync.py
+++ b/sync.py
@@ -11,7 +11,7 @@ repeat-offender table works without anyone ever check-in/check-outing.
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Iterable
 
 import pytz
@@ -25,11 +25,15 @@ WATCH_WINDOW_H = 20  # how far around now to compute live statuses
 
 
 def sync_responses(api) -> int:
-    """Pull all /responses and upsert into the store.
+    """Pull all /responses and upsert into the store, then sweep no-shows.
 
     Returns the count of records ingested. We do a full sweep rather than
     cursor-since because new responses for upcoming shifts can appear at any
     historical position, and the volume is small enough (~8k rows total).
+
+    `mark_no_shows` is invoked at the end of every refresh so that shifts
+    which ended without any kiosk activity get stamped within the 2h full-
+    refresh cadence, not just when the next hot scan window happens to fire.
     """
     db.init()
     rows = api.get_data_from_api("responses") or []
@@ -37,9 +41,10 @@ def sync_responses(api) -> int:
         conn.execute("BEGIN")
         for r in rows:
             db.ingest_response(conn, r)
-        db.set_state(conn, "last_responses_sync_at", datetime.utcnow().isoformat(timespec="seconds"))
+        n_ns = mark_no_shows(conn)
+        db.set_state(conn, "last_responses_sync_at", datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds"))
         conn.execute("COMMIT")
-    logger.info(f"sync_responses ingested {len(rows)} rows")
+    logger.info(f"sync_responses ingested {len(rows)} rows; {n_ns} new no-shows")
     return len(rows)
 
 
@@ -73,7 +78,7 @@ def sync_hours(api, since: datetime | None = None) -> int:
                     user_id=sig.user_id,
                     status=cls,
                 )
-        db.set_state(conn, "last_hours_sync_at", datetime.utcnow().isoformat(timespec="seconds"))
+        db.set_state(conn, "last_hours_sync_at", datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds"))
         conn.execute("COMMIT")
     logger.info(f"sync_hours ingested {len(rows)} rows since {since_str}")
     return len(rows)
@@ -117,7 +122,7 @@ def mark_no_shows(conn) -> int:
             local_end = CHICAGO.localize(datetime.strptime(r["end_ts"], "%Y-%m-%d %H:%M:%S"))
             observed_at = local_end.astimezone(pytz.UTC).replace(tzinfo=None).isoformat(timespec="seconds")
         except (ValueError, TypeError):
-            observed_at = datetime.utcnow().isoformat(timespec="seconds")
+            observed_at = datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds")
         conn.execute(
             "INSERT INTO status_history(response_id,shift_id,user_id,status,observed_at) "
             "VALUES(?,?,?,?,?)",

--- a/sync.py
+++ b/sync.py
@@ -24,6 +24,25 @@ CHICAGO = pytz.timezone("America/Chicago")
 WATCH_WINDOW_H = 20  # how far around now to compute live statuses
 
 
+def sync_needs(api) -> int:
+    """Pull all active /needs and upsert. The /responses payload doesn't
+    include addresses -- only the full need record does. We run this on
+    the same 2h cadence as sync_responses to keep needs.location fresh
+    enough for the gcal push.
+    """
+    db.init()
+    rows = api.get_data_from_api("needs", {"need_status": "active"}) or []
+    with db.connect() as conn:
+        conn.execute("BEGIN")
+        for n in rows:
+            db.upsert_need(conn, n)
+        db.set_state(conn, "last_needs_sync_at",
+                     datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds"))
+        conn.execute("COMMIT")
+    logger.info(f"sync_needs ingested {len(rows)} active needs")
+    return len(rows)
+
+
 def sync_responses(api) -> int:
     """Pull all /responses and upsert into the store, then sweep no-shows.
 
@@ -31,11 +50,14 @@ def sync_responses(api) -> int:
     cursor-since because new responses for upcoming shifts can appear at any
     historical position, and the volume is small enough (~8k rows total).
 
-    `mark_no_shows` is invoked at the end of every refresh so that shifts
-    which ended without any kiosk activity get stamped within the 2h full-
-    refresh cadence, not just when the next hot scan window happens to fire.
+    Also kicks off sync_needs first so any new needs introduced between
+    full refreshes get their addresses indexed before we render them. And
+    mark_no_shows is invoked at the end so shifts that ended without any
+    kiosk activity get stamped within the 2h full-refresh cadence, not
+    just when the next hot scan window happens to fire.
     """
     db.init()
+    sync_needs(api)
     rows = api.get_data_from_api("responses") or []
     with db.connect() as conn:
         conn.execute("BEGIN")

--- a/sync.py
+++ b/sync.py
@@ -1,0 +1,142 @@
+"""Ingest pipeline: Galaxy Digital API -> SQLite (db.py).
+
+Two entry points:
+  - sync_responses(api): paginated full refresh of /responses (cheap; once per
+    REFRESH_INTERVAL_S in the main loop).
+  - sync_hours(api, since): incremental scan of /hours updated since the given
+    timestamp, then derive per-signup status and append to status_history.
+
+A status snapshot is also taken on the SIGNED_UP / NO_SHOW path so the
+repeat-offender table works without anyone ever check-in/check-outing.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable
+
+import pytz
+from loguru import logger
+
+import checkin
+import db
+
+CHICAGO = pytz.timezone("America/Chicago")
+WATCH_WINDOW_H = 20  # how far around now to compute live statuses
+
+
+def sync_responses(api) -> int:
+    """Pull all /responses and upsert into the store.
+
+    Returns the count of records ingested. We do a full sweep rather than
+    cursor-since because new responses for upcoming shifts can appear at any
+    historical position, and the volume is small enough (~8k rows total).
+    """
+    db.init()
+    rows = api.get_data_from_api("responses") or []
+    with db.connect() as conn:
+        conn.execute("BEGIN")
+        for r in rows:
+            db.ingest_response(conn, r)
+        db.set_state(conn, "last_responses_sync_at", datetime.utcnow().isoformat(timespec="seconds"))
+        conn.execute("COMMIT")
+    logger.info(f"sync_responses ingested {len(rows)} rows")
+    return len(rows)
+
+
+def sync_hours(api, since: datetime | None = None) -> int:
+    """Pull /hours updated since `since` (default: 24h ago) and upsert.
+
+    Also touches status_history for any (response_id) we see so the digest's
+    repeat-offender section sees check-in/checkout activity even outside of
+    the active watch window.
+    """
+    db.init()
+    if since is None:
+        since = datetime.now(CHICAGO) - timedelta(hours=24)
+    since_str = since.astimezone(CHICAGO).strftime("%Y-%m-%d %H:%M")
+    rows = api.get_data_from_api("hours", {"since_updated": since_str}) or []
+    with db.connect() as conn:
+        conn.execute("BEGIN")
+        for h in rows:
+            db.ingest_hour(conn, h)
+            sig = checkin.HourSignal.from_api(h)
+            cls = checkin.classify_hour(sig)
+            if sig.response_id:
+                # Look up the shift_id for status_history denormalization
+                sid_row = conn.execute(
+                    "SELECT shift_id FROM signups WHERE id = ?", (sig.response_id,)
+                ).fetchone()
+                db.record_status(
+                    conn,
+                    response_id=sig.response_id,
+                    shift_id=sid_row["shift_id"] if sid_row else None,
+                    user_id=sig.user_id,
+                    status=cls,
+                )
+        db.set_state(conn, "last_hours_sync_at", datetime.utcnow().isoformat(timespec="seconds"))
+        conn.execute("COMMIT")
+    logger.info(f"sync_hours ingested {len(rows)} rows since {since_str}")
+    return len(rows)
+
+
+def mark_no_shows(conn) -> int:
+    """Sweep for shifts whose end has passed and write NO_SHOW status_history
+    entries for any signup that never produced an hours row.
+
+    `observed_at` is set to the shift's actual end time (UTC-naive ISO) so
+    repeat-offender windows over the last N days reflect actual behavior, not
+    when the backfill happened to run.
+
+    Idempotent: any (response_id) whose last history entry is already NO_SHOW
+    is skipped.
+    """
+    now_ct = datetime.now(CHICAGO).strftime("%Y-%m-%d %H:%M:%S")
+    rows = conn.execute(
+        """SELECT sg.id AS response_id, sg.shift_id, sg.user_id, s.end_ts
+           FROM signups sg
+           JOIN shifts s ON s.id = sg.shift_id
+           LEFT JOIN hours h ON h.response_id = sg.id
+           WHERE s.end_ts < ?
+             AND h.id IS NULL
+             AND (sg.response_status IS NULL OR sg.response_status = 'active')
+        """,
+        (now_ct,),
+    ).fetchall()
+    written = 0
+    for r in rows:
+        before = conn.execute(
+            "SELECT status FROM status_history WHERE response_id = ? ORDER BY id DESC LIMIT 1",
+            (r["response_id"],),
+        ).fetchone()
+        if before and before["status"] == checkin.NO_SHOW:
+            continue
+        # Translate the shift end (assumed America/Chicago) to an ISO timestamp
+        # so date math elsewhere stays consistent. We keep it naive-UTC-ish to
+        # match db.record_status's convention.
+        try:
+            local_end = CHICAGO.localize(datetime.strptime(r["end_ts"], "%Y-%m-%d %H:%M:%S"))
+            observed_at = local_end.astimezone(pytz.UTC).replace(tzinfo=None).isoformat(timespec="seconds")
+        except (ValueError, TypeError):
+            observed_at = datetime.utcnow().isoformat(timespec="seconds")
+        conn.execute(
+            "INSERT INTO status_history(response_id,shift_id,user_id,status,observed_at) "
+            "VALUES(?,?,?,?,?)",
+            (r["response_id"], r["shift_id"], r["user_id"], checkin.NO_SHOW, observed_at),
+        )
+        written += 1
+    return written
+
+
+def current_status_for_signup(conn, response_id: str, user_id: str, shift_end: str | None) -> str:
+    """Resolve the live status for one signup, with the no-show / signed-up
+    distinction made from the shift end-time.
+    """
+    row = conn.execute(
+        "SELECT classification FROM hours WHERE response_id = ? "
+        "ORDER BY updated_at DESC LIMIT 1",
+        (response_id,),
+    ).fetchone()
+    if row and row["classification"]:
+        return row["classification"]
+    # No hour row. signed_up vs no_show by clock.
+    return checkin.status_for(response_id, user_id, shift_end, hour_index={})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Shared pytest fixtures.
+
+Putting these here means individual test files can ask for `db_conn` or
+`tmp_db_path` without each one re-wiring the same scaffolding.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the project root importable so `import db`, `import checkin` etc. work
+# when pytest is invoked from any directory.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path, monkeypatch):
+    """Point db.py at a per-test sqlite file."""
+    p = tmp_path / "test.sqlite3"
+    monkeypatch.setenv("GALAXY_DB_PATH", str(p))
+    # db.py reads DB_PATH at import time; force a reload so the new env var
+    # is honored.
+    import importlib
+    import db
+    importlib.reload(db)
+    return str(p)
+
+
+@pytest.fixture
+def db_conn(tmp_db_path):
+    """Yield an initialized connection to a fresh per-test DB."""
+    import db
+    db.init()
+    with db.connect() as conn:
+        yield conn

--- a/tests/test_checkin.py
+++ b/tests/test_checkin.py
@@ -1,0 +1,97 @@
+"""Unit tests for the status classifier.
+
+These are the lowest-stakes most-frequently-broken bits: getting the
+hour_source substring matching wrong, or the kiosk-in vs kiosk-out
+priority backwards. Lock the behavior down here.
+"""
+from __future__ import annotations
+
+import pytest
+
+import checkin
+
+
+def _hour(source: str = "", response_id: str | None = "r1",
+          user_id: str | None = "u1", status: str = "approved") -> dict:
+    return {
+        "id": "h1",
+        "hour_response_id": response_id,
+        "hour_source": source,
+        "hour_status": status,
+        "hour_date_start": "2026-05-19 10:00:00",
+        "hour_date_end": "2026-05-19 12:00:00",
+        "user": {"id": user_id} if user_id else None,
+    }
+
+
+def test_classify_kiosk_checkin_only():
+    h = checkin.HourSignal.from_api(_hour(source="Added at: /kiosk/storeCheckin/ by user 1"))
+    assert checkin.classify_hour(h) == checkin.CHECKED_IN
+
+
+def test_classify_kiosk_full_roundtrip():
+    h = checkin.HourSignal.from_api(_hour(
+        source="Added at: /kiosk/storeCheckin/ by user 1 Updated at: /kiosk/storeCheckout/ by user 1"
+    ))
+    assert checkin.classify_hour(h) == checkin.CHECKED_OUT
+
+
+def test_classify_manager_added():
+    h = checkin.HourSignal.from_api(_hour(
+        source="Added at: /manager/hours_edit/ by Someone"
+    ))
+    assert checkin.classify_hour(h) == checkin.MANAGER_ENTERED
+
+
+def test_classify_kiosk_in_then_manager_edit_stays_checked_in():
+    """A kiosk-checked-in volunteer whose record was later touched by a
+    manager (but not checked out) is still checked_in, not manager_entered.
+    The kiosk_checked_in property must take priority over manager_entered.
+    """
+    h = checkin.HourSignal.from_api(_hour(
+        source="Added at: /kiosk/storeCheckin/ by user 1 Updated at: /manager/hours/ by Maya"
+    ))
+    assert checkin.classify_hour(h) == checkin.CHECKED_IN
+
+
+def test_status_for_no_hour_future_shift_is_signed_up():
+    s = checkin.status_for(
+        response_id="r1", user_id="u1",
+        shift_end_iso="2099-01-01 00:00:00",
+        hour_index={},
+    )
+    assert s == checkin.SIGNED_UP
+
+
+def test_status_for_no_hour_past_shift_is_no_show():
+    s = checkin.status_for(
+        response_id="r1", user_id="u1",
+        shift_end_iso="2000-01-01 00:00:00",
+        hour_index={},
+    )
+    assert s == checkin.NO_SHOW
+
+
+def test_status_for_prefers_response_match_over_user():
+    """If a user has two simultaneous shifts under one need, only the
+    response_id that matches the hour should be marked checked_in.
+    """
+    h = _hour(source="Added at: /kiosk/storeCheckin/", response_id="r_matched", user_id="u1")
+    idx = checkin.build_hour_index([h])
+    matched = checkin.status_for("r_matched", "u1", None, idx)
+    other = checkin.status_for("r_other_simultaneous", "u1", "2099-01-01 00:00:00", idx)
+    # The matched shift sees CHECKED_IN; the other shift falls back to the
+    # user-id key, which is still that same hour (best-effort -- documented
+    # ambiguity when response_id isn't set on the hour).
+    assert matched == checkin.CHECKED_IN
+    # When the hour HAS a response_id we should NOT spill to other shifts
+    # via the user-id fallback. Verify the fallback key isn't populated.
+    assert "u:u1" not in idx
+    assert other == checkin.SIGNED_UP
+
+
+def test_build_hour_index_user_fallback_when_no_response_id():
+    h = _hour(source="Added at: /kiosk/storeCheckin/", response_id=None, user_id="u1")
+    idx = checkin.build_hour_index([h])
+    assert "u:u1" in idx
+    assert idx["u:u1"].kiosk_checked_in is True

--- a/tests/test_db_and_sync.py
+++ b/tests/test_db_and_sync.py
@@ -1,0 +1,162 @@
+"""Tests for the SQLite ingest path and no-show backfill.
+
+These are credentials-free: they push hand-rolled API payload dicts into
+db.ingest_response / db.ingest_hour and assert on the resulting state.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+import checkin
+import db
+import sync
+
+
+# ----- fixtures specific to these tests -----------------------------------
+
+
+def _resp(response_id: str, user_id: str, shift_id: str, *,
+          shift_start: str = "2026-05-19 10:00:00",
+          shift_end: str = "2026-05-19 12:00:00",
+          response_status: str = "active",
+          need_id: str = "n1",
+          agency_name: str = "Agency Test") -> dict:
+    return {
+        "id": response_id,
+        "agency": {"id": "a1", "agency_name": agency_name},
+        "shift": {"id": shift_id, "start": shift_start, "end": shift_end,
+                  "duration": "2.00", "slots": "4"},
+        "need": {"id": need_id, "need_title": "Need Test"},
+        "user": {"id": user_id, "user_fname": "Alice", "user_lname": "T",
+                 "user_email": "alice@example.test"},
+        "response_status": response_status,
+        "created_at": "2026-05-01 09:00:00",
+        "updated_at": "2026-05-01 09:00:00",
+    }
+
+
+def _hour(hour_id: str, response_id: str | None, user_id: str, source: str,
+          need_id: str = "n1") -> dict:
+    return {
+        "id": hour_id,
+        "hour_response_id": response_id,
+        "user": {"id": user_id, "user_fname": "Alice", "user_lname": "T",
+                 "user_email": "alice@example.test"},
+        "need": {"id": need_id, "need_title": "Need Test"},
+        "hour_source": source,
+        "hour_status": "approved",
+        "hour_date_start": "2026-05-19 10:00:00",
+        "hour_date_end":   "2026-05-19 12:00:00",
+        "created_at":      "2026-05-19 10:00:00",
+        "updated_at":      "2026-05-19 10:05:00",
+    }
+
+
+# ----- tests --------------------------------------------------------------
+
+
+def test_ingest_response_populates_all_tables(db_conn):
+    db.ingest_response(db_conn, _resp("r1", "u1", "s1"))
+    counts = {t: db_conn.execute(f"SELECT COUNT(*) AS n FROM {t}").fetchone()["n"]
+              for t in ("users", "needs", "shifts", "signups")}
+    assert counts == {"users": 1, "needs": 1, "shifts": 1, "signups": 1}
+
+    sg = db_conn.execute("SELECT user_id, shift_id, need_id, response_status FROM signups").fetchone()
+    assert sg["user_id"] == "u1"
+    assert sg["shift_id"] == "s1"
+    assert sg["response_status"] == "active"
+
+    n = db_conn.execute("SELECT agency_name FROM needs").fetchone()
+    assert n["agency_name"] == "Agency Test"
+
+
+def test_agency_name_not_overwritten_by_null(db_conn):
+    """The COALESCE in upsert_need must preserve a previously-set agency
+    when a later upsert has no agency info.
+    """
+    db.ingest_response(db_conn, _resp("r1", "u1", "s1", agency_name="First"))
+    # Simulate a second upsert with no agency (e.g. a /needs sweep that
+    # doesn't carry agency in this code path).
+    db.upsert_need(db_conn, {"id": "n1", "need_title": "Updated title"}, agency_name=None)
+    n = db_conn.execute("SELECT title, agency_name FROM needs").fetchone()
+    assert n["title"] == "Updated title"
+    assert n["agency_name"] == "First"
+
+
+def test_ingest_hour_classifies_via_source(db_conn):
+    db.ingest_response(db_conn, _resp("r1", "u1", "s1"))
+    db.ingest_hour(db_conn, _hour("h1", "r1", "u1",
+        source="Added at: /kiosk/storeCheckin/ by user 1"))
+    h = db_conn.execute("SELECT classification, response_id FROM hours").fetchone()
+    assert h["classification"] == checkin.CHECKED_IN
+    assert h["response_id"] == "r1"
+
+
+def test_mark_no_shows_writes_history_with_shift_end_time(db_conn):
+    """The repeat-offender window relies on observed_at == shift end (not
+    backfill wall time), so we can answer 'how many no-shows in the last
+    30 days' correctly even after a big bulk backfill.
+    """
+    # Past shift with no hour row -> should be marked no_show.
+    db.ingest_response(db_conn, _resp("r_past", "u_past", "s_past",
+        shift_start="2020-01-01 10:00:00", shift_end="2020-01-01 12:00:00"))
+    # Future shift with no hour row -> should NOT be marked.
+    db.ingest_response(db_conn, _resp("r_future", "u_future", "s_future",
+        shift_start="2099-01-01 10:00:00", shift_end="2099-01-01 12:00:00"))
+
+    n = sync.mark_no_shows(db_conn)
+    assert n == 1
+
+    rows = db_conn.execute("SELECT response_id, status, observed_at FROM status_history").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["response_id"] == "r_past"
+    assert rows[0]["status"] == checkin.NO_SHOW
+    # observed_at should reflect the shift end (2020 ish), not "now".
+    assert rows[0]["observed_at"].startswith("2020-01-01")
+
+
+def test_mark_no_shows_is_idempotent(db_conn):
+    db.ingest_response(db_conn, _resp("r1", "u1", "s1",
+        shift_start="2020-01-01 10:00:00", shift_end="2020-01-01 12:00:00"))
+    sync.mark_no_shows(db_conn)
+    sync.mark_no_shows(db_conn)
+    n_rows = db_conn.execute("SELECT COUNT(*) AS n FROM status_history").fetchone()["n"]
+    assert n_rows == 1, "second invocation must not duplicate"
+
+
+def test_mark_no_shows_skips_cancellations(db_conn):
+    """A signup with response_status='cancelled' must not become a no-show."""
+    db.ingest_response(db_conn, _resp("r_cancelled", "u1", "s1",
+        shift_start="2020-01-01 10:00:00", shift_end="2020-01-01 12:00:00",
+        response_status="cancelled"))
+    n = sync.mark_no_shows(db_conn)
+    assert n == 0
+
+
+def test_record_status_dedupes_same_status_in_a_row(db_conn):
+    db.record_status(db_conn, response_id="r1", shift_id="s1", user_id="u1",
+                     status=checkin.CHECKED_IN)
+    db.record_status(db_conn, response_id="r1", shift_id="s1", user_id="u1",
+                     status=checkin.CHECKED_IN)
+    db.record_status(db_conn, response_id="r1", shift_id="s1", user_id="u1",
+                     status=checkin.CHECKED_OUT)
+    db.record_status(db_conn, response_id="r1", shift_id="s1", user_id="u1",
+                     status=checkin.CHECKED_OUT)
+    rows = db_conn.execute("SELECT status FROM status_history ORDER BY id").fetchall()
+    assert [r["status"] for r in rows] == [checkin.CHECKED_IN, checkin.CHECKED_OUT]
+
+
+def test_repeat_offenders_respects_window(db_conn):
+    # Two users, each with 2 historical no-shows: one inside 30d, one outside.
+    db.ingest_response(db_conn, _resp("r_a1", "u_a", "s_a1",
+        shift_start="2020-01-01 10:00:00", shift_end="2020-01-01 12:00:00"))
+    db.ingest_response(db_conn, _resp("r_a2", "u_a", "s_a2",
+        shift_start="2020-01-02 10:00:00", shift_end="2020-01-02 12:00:00"))
+    sync.mark_no_shows(db_conn)
+    rows = db.repeat_offenders(db_conn, days=30, min_count=2)
+    assert rows == [], "old no-shows must fall outside 30d window"
+    rows_all = db.repeat_offenders(db_conn, days=9999, min_count=2)
+    assert len(rows_all) == 1
+    assert rows_all[0]["no_shows"] == 2

--- a/tests/test_db_and_sync.py
+++ b/tests/test_db_and_sync.py
@@ -148,6 +148,46 @@ def test_record_status_dedupes_same_status_in_a_row(db_conn):
     assert [r["status"] for r in rows] == [checkin.CHECKED_IN, checkin.CHECKED_OUT]
 
 
+def test_compose_location_full_address():
+    n = {"need_address": "905 W Eastman St.", "need_address2": "",
+         "need_city": "Chicago", "need_state": "IL", "need_postal": "60642"}
+    assert db.compose_location(n) == "905 W Eastman St., Chicago, IL 60642"
+
+
+def test_compose_location_with_unit():
+    n = {"need_address": "1440 N Kingsbury St", "need_address2": "suite 005",
+         "need_city": "Chicago", "need_state": "IL", "need_postal": "60642"}
+    assert db.compose_location(n) == "1440 N Kingsbury St, suite 005, Chicago, IL 60642"
+
+
+def test_compose_location_missing_pieces_skipped():
+    n = {"need_address": "Park entrance", "need_address2": None,
+         "need_city": "Chicago", "need_state": "", "need_postal": ""}
+    assert db.compose_location(n) == "Park entrance, Chicago"
+
+
+def test_compose_location_none_when_all_empty():
+    assert db.compose_location({}) is None
+    assert db.compose_location({"need_address": "", "need_city": ""}) is None
+
+
+def test_upsert_need_writes_location_and_preserves_on_null(db_conn):
+    db.upsert_need(db_conn, {
+        "id": "n1", "need_title": "Test",
+        "need_address": "100 Main", "need_city": "Chicago",
+        "need_state": "IL", "need_postal": "60601",
+    })
+    row = db_conn.execute("SELECT title, location FROM needs WHERE id='n1'").fetchone()
+    assert row["location"] == "100 Main, Chicago, IL 60601"
+
+    # Later ingest path (e.g. a /responses sweep) carries no address.
+    # The location must survive untouched.
+    db.upsert_need(db_conn, {"id": "n1", "need_title": "Updated title"})
+    row = db_conn.execute("SELECT title, location FROM needs WHERE id='n1'").fetchone()
+    assert row["title"] == "Updated title"
+    assert row["location"] == "100 Main, Chicago, IL 60601"
+
+
 def test_repeat_offenders_respects_window(db_conn):
     # Two users, each with 2 historical no-shows: one inside 30d, one outside.
     db.ingest_response(db_conn, _resp("r_a1", "u_a", "s_a1",

--- a/tests/test_gcal_push.py
+++ b/tests/test_gcal_push.py
@@ -1,0 +1,126 @@
+"""End-to-end roundtrip against a real Google Calendar.
+
+This is gated behind the GCAL_TEST_CALENDAR_ID env var. If unset (the
+common case in CI or on a fresh checkout) the test is skipped so the
+suite is still green. Set it to the calendar ID of a *throwaway*
+calendar you don't mind getting events created and deleted in.
+
+To run locally:
+    export GCAL_TEST_CALENDAR_ID=<calendar id>
+    pytest tests/test_gcal_push.py -v
+
+What it covers:
+  1. gcal.get_service() actually authenticates and returns a usable
+     Calendar v3 client.
+  2. gcal.update_calendar_events creates a new event with the expected
+     title and emoji-decorated description.
+  3. Calling it again with the same shift id is an idempotent UPDATE
+     (not a duplicate insert).
+  4. The event can be cleanly deleted afterwards.
+"""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+
+import checkin
+import gcal
+
+TEST_CAL = os.getenv("GCAL_TEST_CALENDAR_ID")
+
+pytestmark = pytest.mark.skipif(
+    not TEST_CAL,
+    reason="GCAL_TEST_CALENDAR_ID not set; skipping live gcal test",
+)
+
+
+def _make_shift(shift_id: str, when: datetime) -> dict:
+    """Build a shift dict in the shape gcal.update_calendar_events expects."""
+    return {
+        "id": shift_id,
+        "title": f"PYTEST roundtrip {shift_id[:6]}",
+        "slots_filled": 2,
+        "slots": 4,
+        "start_time": when,
+        "end_time": when + timedelta(hours=1),
+        "users": [
+            {
+                "id": "u1",
+                "response_id": "r1",
+                "user_fname": "Alice",
+                "user_lname": "Test",
+                "user_email": "alice@example.test",
+                "checkin_status": checkin.CHECKED_IN,
+            },
+            {
+                "id": "u2",
+                "response_id": "r2",
+                "user_fname": "Bob",
+                "user_lname": "Test",
+                "user_email": "bob@example.test",
+                "checkin_status": checkin.NO_SHOW,
+            },
+        ],
+    }
+
+
+def _fetch(svc, event_id: str):
+    return svc.events().get(calendarId=TEST_CAL, eventId=event_id).execute()
+
+
+def _delete(svc, event_id: str) -> None:
+    try:
+        svc.events().delete(calendarId=TEST_CAL, eventId=event_id).execute()
+    except Exception:
+        # Already gone or never created -- nothing to clean up.
+        pass
+
+
+def test_create_update_delete_roundtrip():
+    """Push a synthetic shift, read it back, push again (idempotent
+    update), then delete it. All four checkpoints must succeed.
+    """
+    svc = gcal.get_service()
+    # Pick an event id that's globally unique to this run so we don't
+    # collide with previous test runs or real data. gcal IDs must be
+    # base32hex-ish (lowercase a-v + 0-9), 5-1024 chars.
+    event_id = f"pytest{uuid.uuid4().hex[:20]}"
+    when = datetime.now() + timedelta(days=365)  # far in the future so it
+                                                  # doesn't pollute "today" views
+    shift = _make_shift(event_id, when)
+
+    try:
+        # 1. Create
+        gcal.update_calendar_events([shift], svc, calendar_id=TEST_CAL, add_attendees=False)
+        time.sleep(1.0)  # give Google a moment to materialize the write
+
+        got = _fetch(svc, event_id)
+        assert got["summary"].startswith("PYTEST roundtrip")
+        assert "(2/4)" in got["summary"]
+        # Emoji-decorated signup list should be in the description.
+        desc = got.get("description", "")
+        assert "Alice Test" in desc
+        assert "Bob Test" in desc
+        assert checkin.STATUS_EMOJI[checkin.CHECKED_IN] in desc
+        assert checkin.STATUS_EMOJI[checkin.NO_SHOW] in desc
+
+        # 2. Update -- flip Alice to checked_out and re-push the same id.
+        shift["users"][0]["checkin_status"] = checkin.CHECKED_OUT
+        gcal.update_calendar_events([shift], svc, calendar_id=TEST_CAL, add_attendees=False)
+        time.sleep(1.0)
+        got2 = _fetch(svc, event_id)
+        assert checkin.STATUS_EMOJI[checkin.CHECKED_OUT] in got2.get("description", "")
+        # Still the same single event -- no duplicate.
+        listing = svc.events().list(
+            calendarId=TEST_CAL,
+            q="PYTEST roundtrip",
+            singleEvents=True,
+        ).execute()
+        ids = {e["id"] for e in listing.get("items", [])}
+        assert event_id in ids, "event vanished after update"
+    finally:
+        _delete(svc, event_id)

--- a/tests/test_gcal_push.py
+++ b/tests/test_gcal_push.py
@@ -47,6 +47,7 @@ def _make_shift(shift_id: str, when: datetime) -> dict:
         "slots": 4,
         "start_time": when,
         "end_time": when + timedelta(hours=1),
+        "location": "905 W Eastman St., Chicago, IL 60642",
         "users": [
             {
                 "id": "u1",
@@ -86,9 +87,12 @@ def test_create_update_delete_roundtrip():
     """
     svc = gcal.get_service()
     # Pick an event id that's globally unique to this run so we don't
-    # collide with previous test runs or real data. gcal IDs must be
-    # base32hex-ish (lowercase a-v + 0-9), 5-1024 chars.
-    event_id = f"pytest{uuid.uuid4().hex[:20]}"
+    # collide with previous test runs or real data. Google's event IDs
+    # are RFC2938 base32hex: lowercase a-v + 0-9 only, 5-1024 chars.
+    # uuid.uuid4().hex (0-9 + a-f) is always valid; prefixing with
+    # "demoshift" (d,e,m,o,s,h,i,f,t are all in a-v) keeps it readable
+    # in the calendar's all-events view.
+    event_id = f"demoshift{uuid.uuid4().hex}"
     when = datetime.now() + timedelta(days=365)  # far in the future so it
                                                   # doesn't pollute "today" views
     shift = _make_shift(event_id, when)
@@ -101,6 +105,7 @@ def test_create_update_delete_roundtrip():
         got = _fetch(svc, event_id)
         assert got["summary"].startswith("PYTEST roundtrip")
         assert "(2/4)" in got["summary"]
+        assert got.get("location") == "905 W Eastman St., Chicago, IL 60642"
         # Emoji-decorated signup list should be in the description.
         desc = got.get("description", "")
         assert "Alice Test" in desc

--- a/tests/test_web_sse.py
+++ b/tests/test_web_sse.py
@@ -1,0 +1,88 @@
+"""Tests for the SSE fingerprint + frame formatter.
+
+We don't drive the live async generator here -- that requires a uvicorn
+loop and adds flakiness for a logic test. Instead we exercise the two
+pieces the streaming endpoint depends on:
+
+  - _render_today_body(conn) -> (html, fp): fingerprint must be stable
+    across calls with no DB change, and must move when a displayed value
+    changes (status, name, kiosk times, etc.).
+  - _sse(event, data): produces a well-formed SSE frame.
+
+If both invariants hold, the live loop's correctness reduces to "yield
+when fp changes", which is straightforward.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def web_module(monkeypatch):
+    """web.py reads WEB_PASSWORD at import; supply one so the module is
+    importable even on a fresh process.
+    """
+    monkeypatch.setenv("WEB_PASSWORD", "irrelevant")
+    import importlib
+    import web
+    importlib.reload(web)
+    return web
+
+
+def _seed_one_today_shift(conn):
+    """Insert one shift dated today (Chicago local) with two signups."""
+    import db
+    today = conn.execute("SELECT date('now','localtime') AS d").fetchone()["d"]
+    start = f"{today} 10:00:00"
+    end = f"{today} 12:00:00"
+    db.ingest_response(conn, {
+        "id": "r_a", "agency": {"id": "1", "agency_name": "Test Agency"},
+        "shift": {"id": "s_today", "start": start, "end": end, "duration": "2", "slots": "4"},
+        "need": {"id": "n", "need_title": "Test Need"},
+        "user": {"id": "u_a", "user_fname": "Ann", "user_lname": "Alpha", "user_email": "a@x.test"},
+        "response_status": "active",
+    })
+    db.ingest_response(conn, {
+        "id": "r_b", "agency": {"id": "1", "agency_name": "Test Agency"},
+        "shift": {"id": "s_today", "start": start, "end": end, "duration": "2", "slots": "4"},
+        "need": {"id": "n", "need_title": "Test Need"},
+        "user": {"id": "u_b", "user_fname": "Bob", "user_lname": "Beta", "user_email": "b@x.test"},
+        "response_status": "active",
+    })
+
+
+def test_render_today_body_fingerprint_stable_across_calls(db_conn, web_module):
+    _seed_one_today_shift(db_conn)
+    html1, fp1 = web_module._render_today_body(db_conn)
+    html2, fp2 = web_module._render_today_body(db_conn)
+    assert fp1 == fp2
+    assert html1 == html2
+
+
+def test_render_today_body_fingerprint_changes_when_name_changes(db_conn, web_module):
+    _seed_one_today_shift(db_conn)
+    _, fp1 = web_module._render_today_body(db_conn)
+    db_conn.execute("UPDATE users SET fname = 'Annabel' WHERE id = 'u_a'")
+    _, fp2 = web_module._render_today_body(db_conn)
+    assert fp1 != fp2
+
+
+def test_render_today_body_empty_when_no_shifts(db_conn, web_module):
+    """Empty days are still renderable -- this was the original 500 bug."""
+    html, fp = web_module._render_today_body(db_conn)
+    assert "No shifts scheduled today" in html
+    assert len(fp) == 40  # sha1 hex
+
+
+def test_sse_frame_format(web_module):
+    frame = web_module._sse("today", "hello\nworld")
+    # SSE spec: event line, then one `data:` line per source-line, then blank.
+    assert frame == "event: today\ndata: hello\ndata: world\n\n"
+
+
+def test_sse_frame_empty_data(web_module):
+    """Even an empty payload must terminate with the spec-required blank line."""
+    frame = web_module._sse("ping", "")
+    assert frame == "event: ping\ndata: \n\n"

--- a/verify_galaxy_creds.py
+++ b/verify_galaxy_creds.py
@@ -1,0 +1,60 @@
+"""Smoke-test Galaxy Digital API credentials in .env.
+
+Run: `python verify_galaxy_creds.py`. Exits 0 on success, 1 on failure.
+Prints which endpoints work and surfaces one sample record per endpoint
+so the field shapes can be confirmed against api.yaml.
+"""
+import os
+import sys
+import json
+import requests
+from dotenv import load_dotenv
+
+
+def main() -> int:
+    load_dotenv()
+    api_key = (os.getenv("API_KEY") or "").strip()
+    email = (os.getenv("EMAIL") or "").strip()
+    password = (os.getenv("PASSWORD") or "").strip()
+
+    missing = [n for n, v in [("API_KEY", api_key), ("EMAIL", email), ("PASSWORD", password)] if not v]
+    if missing:
+        print(f"missing env vars: {missing}")
+        return 1
+
+    base = "https://api.galaxydigital.com/api"
+    print(f"login: POST {base}/users/login as {email!r}")
+    r = requests.post(
+        f"{base}/users/login",
+        headers={"Accept": "application/json", "Content-Type": "application/json"},
+        json={"key": api_key, "user_email": email, "user_password": password},
+        timeout=15,
+    )
+    if r.status_code != 200:
+        print(f"  -> HTTP {r.status_code}: {r.text[:300]}")
+        print("  fix: update API_KEY / EMAIL / PASSWORD in .env, then rerun.")
+        return 1
+
+    payload = r.json()
+    token = payload["data"]["token"] if isinstance(payload.get("data"), dict) else payload["data"][0]["token"]
+    print(f"  -> ok, token prefix={token[:12]}...")
+
+    headers = {"Accept": "application/json", "Authorization": f"Bearer {token}"}
+    for path, params in [
+        ("responses", {"per_page": 1}),
+        ("hours", {"per_page": 1}),
+        ("users", {"per_page": 1}),
+        ("needs", {"per_page": 1}),
+    ]:
+        r = requests.get(f"{base}/{path}", headers=headers, json=params, timeout=15)
+        ok = r.status_code == 200
+        data = r.json().get("data") if ok else None
+        sample = data[0] if data else None
+        print(f"GET /{path}: HTTP {r.status_code}  records={len(data) if data else 0}")
+        if sample:
+            print(f"  sample keys: {sorted(sample.keys())}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web.py
+++ b/web.py
@@ -43,6 +43,15 @@ app = FastAPI(title="Galaxy Digital live status")
 security = HTTPBasic(auto_error=False)
 
 
+@app.on_event("startup")
+def _ensure_schema() -> None:
+    """Create the SQLite schema on first launch so the viewer doesn't 500
+    when the operator hits / before run_cal_update.py has done its first
+    ingest. The tables will be empty until then -- but empty is renderable.
+    """
+    db.init()
+
+
 def _require_auth(creds: Annotated[HTTPBasicCredentials | None, Depends(security)]):
     if not WEB_PASSWORD:
         # Refuse to serve anything if the operator hasn't set a password --

--- a/web.py
+++ b/web.py
@@ -91,8 +91,8 @@ nav a:hover { text-decoration: underline; }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 5px 8px; text-align: left; border-bottom: 1px solid #f0f0f0; font-size: 0.93em; }
 tr.no-show { background: #fff4f4; }
-tr.checked-in { background: #f1faf2; }
-tr.checked-out { background: #f1f5fa; }
+tr.checked-in { background: #fffbe6; }   /* 🟡 at the kiosk now */
+tr.checked-out { background: #f1faf2; }  /* 🟢 done for the day */
 .empty { color: #888; font-style: italic; }
 """
 

--- a/web.py
+++ b/web.py
@@ -1,0 +1,269 @@
+"""Local FastAPI webapp for real-time check-in visibility.
+
+Reads from the SQLite store (db.py). The sync loop in run_cal_update.py
+writes to that same DB, so this app is purely a viewer -- no Galaxy API
+calls from web request paths.
+
+Pages:
+  /                 today's shifts + live status
+  /shift/{id}       drill-down for one shift
+  /offenders        repeat no-shows (configurable window)
+  /digest           today's digest (HTML format)
+  /api/today.json   machine-readable view of /
+
+Auth: single shared password via env WEB_PASSWORD (HTTP Basic). If unset,
+the app refuses to start to avoid accidentally exposing PII to the LAN.
+
+Run: uvicorn web:app --host 0.0.0.0 --port ${WEB_PORT:-8765}
+"""
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import datetime, timedelta
+from typing import Annotated
+
+import pytz
+from fastapi import Depends, FastAPI, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+import checkin
+import db
+import digest as digest_mod
+
+CHICAGO = pytz.timezone("America/Chicago")
+
+WEB_PASSWORD = os.getenv("WEB_PASSWORD")
+WEB_USERNAME = os.getenv("WEB_USERNAME", "volunteer")
+# How many seconds between auto-refreshes on the live page.
+REFRESH_SECS = int(os.getenv("WEB_REFRESH_SECS", "60"))
+
+app = FastAPI(title="Galaxy Digital live status")
+security = HTTPBasic(auto_error=False)
+
+
+def _require_auth(creds: Annotated[HTTPBasicCredentials | None, Depends(security)]):
+    if not WEB_PASSWORD:
+        # Refuse to serve anything if the operator hasn't set a password --
+        # this page lists volunteer emails so it must not be wide-open by
+        # default.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="WEB_PASSWORD env var must be set before the server will serve requests.",
+        )
+    if creds is None or not (
+        secrets.compare_digest(creds.username, WEB_USERNAME)
+        and secrets.compare_digest(creds.password, WEB_PASSWORD)
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Auth required",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return creds
+
+
+PAGE_CSS = """
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       color: #1a1a1a; max-width: 980px; margin: 0 auto; padding: 1em; background: #fafbfc; }
+header { display: flex; justify-content: space-between; align-items: baseline;
+         border-bottom: 1px solid #e2e4e8; padding-bottom: 0.5em; margin-bottom: 1em; }
+header h1 { margin: 0; color: #2a4d69; }
+nav a { margin-left: 1em; color: #2a4d69; text-decoration: none; }
+nav a:hover { text-decoration: underline; }
+.meta { color: #777; font-size: 0.9em; }
+.shift { background: white; border: 1px solid #e2e4e8; border-radius: 8px;
+         margin: 1em 0; padding: 0.9em 1em; }
+.shift h3 { margin: 0 0 0.2em 0; }
+.shift .meta { margin-bottom: 0.5em; }
+.bar { display: flex; gap: 0.6em; flex-wrap: wrap; font-size: 0.9em; margin: 0.3em 0 0.5em; }
+.bar span { background: #f0f3f7; padding: 2px 8px; border-radius: 12px; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 5px 8px; text-align: left; border-bottom: 1px solid #f0f0f0; font-size: 0.93em; }
+tr.no-show { background: #fff4f4; }
+tr.checked-in { background: #f1faf2; }
+tr.checked-out { background: #f1f5fa; }
+.empty { color: #888; font-style: italic; }
+"""
+
+
+def _layout(title: str, body: str, refresh: bool = False) -> str:
+    refresh_tag = f'<meta http-equiv="refresh" content="{REFRESH_SECS}">' if refresh else ""
+    return f"""<!doctype html>
+<html><head><meta charset="utf-8">{refresh_tag}<title>{title}</title>
+<style>{PAGE_CSS}</style></head>
+<body>
+<header>
+<h1>Galaxy Digital · live</h1>
+<nav>
+  <a href="/">Today</a>
+  <a href="/offenders">Repeat no-shows</a>
+  <a href="/digest">Digest</a>
+</nav>
+</header>
+{body}
+<p class="meta">Page auto-refreshes every {REFRESH_SECS}s · generated {datetime.now(CHICAGO).strftime('%Y-%m-%d %H:%M %Z')}</p>
+</body></html>"""
+
+
+def _row_for_signup(sg, shift_end_ts: str | None) -> dict:
+    """Resolve display row for one (signup + maybe-hour) pair."""
+    status = sg["classification"]
+    if not status:
+        now_ct = datetime.now(CHICAGO).strftime("%Y-%m-%d %H:%M:%S")
+        status = checkin.NO_SHOW if shift_end_ts and shift_end_ts < now_ct else checkin.SIGNED_UP
+    src = (sg["source"] or "") if "source" in sg.keys() else ""
+    return {
+        "name": f"{sg['fname'] or ''} {sg['lname'] or ''}".strip(),
+        "email": sg["email"] or "",
+        "status": status,
+        "emoji": checkin.STATUS_EMOJI.get(status, "🔘"),
+        "check_in": sg["date_start"] if "/kiosk/storeCheckin/".lower() in src.lower() else None,
+        "check_out": sg["date_end"] if "/kiosk/storeCheckout/".lower() in src.lower() else None,
+    }
+
+
+@app.get("/", response_class=HTMLResponse)
+def today(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
+    with db.connect() as conn:
+        shifts = db.shifts_for_day(conn)
+        rendered = []
+        for s in shifts:
+            sgs = db.signups_for_shift(conn, s["id"])
+            people = [_row_for_signup(r, s["end_ts"]) for r in sgs]
+            counts: dict[str, int] = {}
+            for p in people:
+                counts[p["status"]] = counts.get(p["status"], 0) + 1
+            rendered.append({"shift": s, "people": people, "counts": counts})
+
+    if not rendered:
+        body = "<p class='empty'>No shifts scheduled today.</p>"
+        return HTMLResponse(_layout("Today", body, refresh=True))
+
+    parts = ["<h2>Today's shifts</h2>"]
+    for blk in rendered:
+        s = blk["shift"]
+        c = blk["counts"]
+        title = s["title"] or "(no title)"
+        agency = s["agency_name"] or ""
+        start = (s["start_ts"] or "")[11:16]
+        end = (s["end_ts"] or "")[11:16]
+        parts.append(f'<div class="shift"><h3><a href="/shift/{s["id"]}">{title}</a></h3>')
+        parts.append(f'<div class="meta">{agency} · {start}–{end} · '
+                     f'{sum(c.values())}/{s["slots"]} filled</div>')
+        parts.append('<div class="bar">')
+        for k in (checkin.CHECKED_IN, checkin.CHECKED_OUT, checkin.SIGNED_UP,
+                  checkin.NO_SHOW, checkin.MANAGER_ENTERED):
+            n = c.get(k, 0)
+            if n:
+                parts.append(f"<span>{checkin.STATUS_EMOJI[k]} {n} {k.replace('_',' ')}</span>")
+        parts.append('</div>')
+        if blk["people"]:
+            parts.append('<table><thead><tr><th></th><th>Volunteer</th><th>Email</th>'
+                         '<th>In</th><th>Out</th></tr></thead><tbody>')
+            for p in blk["people"]:
+                tr_cls = ""
+                if p["status"] == checkin.NO_SHOW:    tr_cls = " class='no-show'"
+                elif p["status"] == checkin.CHECKED_IN:  tr_cls = " class='checked-in'"
+                elif p["status"] == checkin.CHECKED_OUT: tr_cls = " class='checked-out'"
+                parts.append(
+                    f"<tr{tr_cls}><td>{p['emoji']}</td>"
+                    f"<td>{p['name']}</td><td>{p['email']}</td>"
+                    f"<td>{(p['check_in'] or '')[11:16]}</td>"
+                    f"<td>{(p['check_out'] or '')[11:16]}</td></tr>"
+                )
+            parts.append('</tbody></table>')
+        parts.append('</div>')
+    return HTMLResponse(_layout("Today", "\n".join(parts), refresh=True))
+
+
+@app.get("/shift/{shift_id}", response_class=HTMLResponse)
+def shift_detail(shift_id: str,
+                 _: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
+    with db.connect() as conn:
+        s = conn.execute(
+            "SELECT s.*, n.title, n.agency_name FROM shifts s "
+            "LEFT JOIN needs n ON n.id = s.need_id WHERE s.id = ?",
+            (shift_id,),
+        ).fetchone()
+        if not s:
+            raise HTTPException(404, "shift not found")
+        sgs = db.signups_for_shift(conn, shift_id)
+        people = [_row_for_signup(r, s["end_ts"]) for r in sgs]
+        hist = conn.execute(
+            """SELECT status, observed_at FROM status_history
+               WHERE shift_id = ? ORDER BY id DESC LIMIT 25""",
+            (shift_id,),
+        ).fetchall()
+
+    parts = [f'<h2>{s["title"] or "(no title)"}</h2>']
+    parts.append(f'<div class="meta">{s["agency_name"] or ""} · '
+                 f'{s["start_ts"]} → {s["end_ts"]} · slots={s["slots"]}</div>')
+    parts.append('<table><thead><tr><th></th><th>Volunteer</th><th>Email</th>'
+                 '<th>Status</th><th>In</th><th>Out</th></tr></thead><tbody>')
+    for p in people:
+        parts.append(f"<tr><td>{p['emoji']}</td><td>{p['name']}</td><td>{p['email']}</td>"
+                     f"<td>{p['status']}</td><td>{p['check_in'] or ''}</td>"
+                     f"<td>{p['check_out'] or ''}</td></tr>")
+    parts.append('</tbody></table>')
+    parts.append('<h3>Recent status changes</h3>')
+    if hist:
+        parts.append('<table><thead><tr><th>When (UTC)</th><th>Status</th></tr></thead><tbody>')
+        for h in hist:
+            parts.append(f"<tr><td>{h['observed_at']}</td><td>{h['status']}</td></tr>")
+        parts.append('</tbody></table>')
+    else:
+        parts.append("<p class='empty'>No recorded status changes.</p>")
+    parts.append('<p><a href="/">&laquo; back to today</a></p>')
+    return HTMLResponse(_layout(s["title"] or "Shift", "\n".join(parts), refresh=True))
+
+
+@app.get("/offenders", response_class=HTMLResponse)
+def offenders(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)],
+              days: int = 30, min_count: int = 2):
+    with db.connect() as conn:
+        rows = db.repeat_offenders(conn, days=days, min_count=min_count)
+    parts = [f'<h2>Repeat no-shows · last {days} days (min {min_count})</h2>']
+    parts.append('<p class="meta">')
+    for d in (7, 30, 90, 365):
+        parts.append(f' <a href="/offenders?days={d}&min_count={min_count}">last {d}d</a>')
+    parts.append('</p>')
+    if not rows:
+        parts.append("<p class='empty'>No repeat offenders in this window. 🎉</p>")
+    else:
+        parts.append('<table><thead><tr><th>Volunteer</th><th>Email</th><th>No-shows</th>'
+                     '</tr></thead><tbody>')
+        for r in rows:
+            parts.append(
+                f"<tr><td>{(r['fname'] or '')} {(r['lname'] or '')}</td>"
+                f"<td>{r['email'] or ''}</td><td>{r['no_shows']}</td></tr>"
+            )
+        parts.append('</tbody></table>')
+    return HTMLResponse(_layout("Repeat no-shows", "\n".join(parts), refresh=False))
+
+
+@app.get("/digest", response_class=HTMLResponse)
+def view_digest(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)], days: int = 1):
+    data = digest_mod.collect(days_back=days)
+    html = digest_mod.render_html(data)
+    return HTMLResponse(_layout("Digest preview", html, refresh=False))
+
+
+@app.get("/api/today.json")
+def api_today(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
+    with db.connect() as conn:
+        shifts = db.shifts_for_day(conn)
+        out = []
+        for s in shifts:
+            sgs = db.signups_for_shift(conn, s["id"])
+            out.append({
+                "id": s["id"],
+                "title": s["title"],
+                "agency": s["agency_name"],
+                "start": s["start_ts"],
+                "end": s["end_ts"],
+                "slots": s["slots"],
+                "people": [_row_for_signup(r, s["end_ts"]) for r in sgs],
+            })
+    return JSONResponse(out)

--- a/web.py
+++ b/web.py
@@ -5,11 +5,20 @@ writes to that same DB, so this app is purely a viewer -- no Galaxy API
 calls from web request paths.
 
 Pages:
-  /                 today's shifts + live status
+  /                 today's shifts + live status (SSE-driven)
   /shift/{id}       drill-down for one shift
   /offenders        repeat no-shows (configurable window)
   /digest           today's digest (HTML format)
   /api/today.json   machine-readable view of /
+  /events           Server-Sent Events stream pushing today's HTML
+                    fragment whenever the underlying SQLite state changes.
+
+Live updates: the page no longer meta-refreshes. Instead it opens an
+EventSource against /events; the server polls the DB every SSE_POLL_SECS
+(default 5s) and only sends a frame when the (response_id, status,
+checkin_time, checkout_time) fingerprint of today's roster changes.
+Heartbeat comments are sent in between so proxies / browsers don't
+idle-close the connection.
 
 Auth: single shared password via env WEB_PASSWORD (HTTP Basic). If unset,
 the app refuses to start to avoid accidentally exposing PII to the LAN.
@@ -18,14 +27,18 @@ Run: uvicorn web:app --host 0.0.0.0 --port ${WEB_PORT:-8765}
 """
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import os
 import secrets
 from datetime import datetime, timedelta
-from typing import Annotated
+from typing import Annotated, AsyncIterator
 
 import pytz
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 import checkin
@@ -36,20 +49,26 @@ CHICAGO = pytz.timezone("America/Chicago")
 
 WEB_PASSWORD = os.getenv("WEB_PASSWORD")
 WEB_USERNAME = os.getenv("WEB_USERNAME", "volunteer")
-# How many seconds between auto-refreshes on the live page.
-REFRESH_SECS = int(os.getenv("WEB_REFRESH_SECS", "60"))
+# How often the SSE endpoint re-queries SQLite to look for changes. Keep
+# this small (1-5s) -- the work is one indexed query plus a hash; the
+# stream only emits when the fingerprint actually changes.
+SSE_POLL_SECS = float(os.getenv("WEB_SSE_POLL_SECS", "5"))
+SSE_HEARTBEAT_SECS = float(os.getenv("WEB_SSE_HEARTBEAT_SECS", "20"))
 
-app = FastAPI(title="Galaxy Digital live status")
-security = HTTPBasic(auto_error=False)
-
-
-@app.on_event("startup")
-def _ensure_schema() -> None:
+@asynccontextmanager
+async def _lifespan(app):
     """Create the SQLite schema on first launch so the viewer doesn't 500
     when the operator hits / before run_cal_update.py has done its first
     ingest. The tables will be empty until then -- but empty is renderable.
+
+    Uses the modern lifespan API rather than the deprecated on_event hook.
     """
     db.init()
+    yield
+
+
+app = FastAPI(title="Galaxy Digital live status", lifespan=_lifespan)
+security = HTTPBasic(auto_error=False)
 
 
 def _require_auth(creds: Annotated[HTTPBasicCredentials | None, Depends(security)]):
@@ -97,10 +116,41 @@ tr.checked-out { background: #f1faf2; }  /* 🟢 done for the day */
 """
 
 
-def _layout(title: str, body: str, refresh: bool = False) -> str:
-    refresh_tag = f'<meta http-equiv="refresh" content="{REFRESH_SECS}">' if refresh else ""
+SSE_CLIENT_JS = """
+<script>
+// Open a Server-Sent Events stream and patch the shifts container in
+// place when the server tells us the roster changed. Falls back to a
+// 60s page reload if SSE isn't supported (very old browsers).
+(function(){
+  if (typeof EventSource === 'undefined') {
+    setTimeout(function(){ location.reload(); }, 60000);
+    return;
+  }
+  var es = new EventSource('/events');
+  es.addEventListener('today', function(ev){
+    var c = document.getElementById('shifts-container');
+    if (c) c.innerHTML = ev.data;
+    var stamp = document.getElementById('updated-at');
+    if (stamp) stamp.textContent = new Date().toLocaleTimeString();
+  });
+  es.onerror = function(){
+    // EventSource auto-reconnects with backoff -- nothing to do here,
+    // but log it so misconfiguration shows up in devtools.
+    console.warn('SSE stream dropped; browser will retry.');
+  };
+})();
+</script>
+"""
+
+
+def _layout(title: str, body: str, live: bool = False) -> str:
+    """Wrap `body` in the site chrome. If `live` is true, embed the SSE
+    client JS that swaps #shifts-container in place when /events fires.
+    """
+    live_script = SSE_CLIENT_JS if live else ""
+    stamp = datetime.now(CHICAGO).strftime("%H:%M:%S")
     return f"""<!doctype html>
-<html><head><meta charset="utf-8">{refresh_tag}<title>{title}</title>
+<html><head><meta charset="utf-8"><title>{title}</title>
 <style>{PAGE_CSS}</style></head>
 <body>
 <header>
@@ -112,7 +162,8 @@ def _layout(title: str, body: str, refresh: bool = False) -> str:
 </nav>
 </header>
 {body}
-<p class="meta">Page auto-refreshes every {REFRESH_SECS}s · generated {datetime.now(CHICAGO).strftime('%Y-%m-%d %H:%M %Z')}</p>
+<p class="meta">{('Live: updated <span id="updated-at">' + stamp + '</span>' if live else 'generated ' + datetime.now(CHICAGO).strftime('%Y-%m-%d %H:%M %Z'))}</p>
+{live_script}
 </body></html>"""
 
 
@@ -133,22 +184,30 @@ def _row_for_signup(sg, shift_end_ts: str | None) -> dict:
     }
 
 
-@app.get("/", response_class=HTMLResponse)
-def today(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
-    with db.connect() as conn:
-        shifts = db.shifts_for_day(conn)
-        rendered = []
-        for s in shifts:
-            sgs = db.signups_for_shift(conn, s["id"])
-            people = [_row_for_signup(r, s["end_ts"]) for r in sgs]
-            counts: dict[str, int] = {}
-            for p in people:
-                counts[p["status"]] = counts.get(p["status"], 0) + 1
-            rendered.append({"shift": s, "people": people, "counts": counts})
+def _render_today_body(conn) -> tuple[str, str]:
+    """Build the shifts fragment for today and a fingerprint over it.
+
+    Returning the fingerprint alongside the HTML lets the SSE loop decide
+    whether to push without having to diff strings -- the fingerprint
+    covers the only things that actually affect what's displayed.
+    """
+    shifts = db.shifts_for_day(conn)
+    rendered = []
+    fp_inputs: list[str] = []
+    for s in shifts:
+        sgs = db.signups_for_shift(conn, s["id"])
+        people = [_row_for_signup(r, s["end_ts"]) for r in sgs]
+        counts: dict[str, int] = {}
+        for p in people:
+            counts[p["status"]] = counts.get(p["status"], 0) + 1
+            fp_inputs.append(
+                f"{s['id']}|{p['name']}|{p['status']}|{p['check_in'] or ''}|{p['check_out'] or ''}"
+            )
+        rendered.append({"shift": s, "people": people, "counts": counts})
 
     if not rendered:
         body = "<p class='empty'>No shifts scheduled today.</p>"
-        return HTMLResponse(_layout("Today", body, refresh=True))
+        return body, hashlib.sha1(b"empty").hexdigest()
 
     parts = ["<h2>Today's shifts</h2>"]
     for blk in rendered:
@@ -184,7 +243,71 @@ def today(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
                 )
             parts.append('</tbody></table>')
         parts.append('</div>')
-    return HTMLResponse(_layout("Today", "\n".join(parts), refresh=True))
+
+    body_html = "\n".join(parts)
+    fp = hashlib.sha1("\n".join(sorted(fp_inputs)).encode()).hexdigest()
+    return body_html, fp
+
+
+@app.get("/", response_class=HTMLResponse)
+def today(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
+    with db.connect() as conn:
+        body, _fp = _render_today_body(conn)
+    # The body is wrapped in a container the SSE handler can target.
+    wrapped = f'<div id="shifts-container">{body}</div>'
+    return HTMLResponse(_layout("Today", wrapped, live=True))
+
+
+@app.get("/events")
+async def events_stream(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)]):
+    """Server-Sent Events: push the today fragment when its fingerprint
+    changes; emit a `: heartbeat` comment otherwise so the connection
+    stays warm through proxies.
+
+    Each event uses the SSE field `event: today` so the browser client
+    can dispatch it to one handler regardless of how many event types we
+    add later.
+    """
+
+    async def gen() -> AsyncIterator[str]:
+        last_fp: str | None = None
+        last_heartbeat = asyncio.get_event_loop().time()
+
+        # Push an immediate snapshot so the client can drop the initial
+        # SSR'd body if it wants to without waiting for a real change.
+        with db.connect() as conn:
+            body, fp = _render_today_body(conn)
+        last_fp = fp
+        yield _sse("today", body)
+
+        while True:
+            await asyncio.sleep(SSE_POLL_SECS)
+            with db.connect() as conn:
+                body, fp = _render_today_body(conn)
+            now = asyncio.get_event_loop().time()
+            if fp != last_fp:
+                last_fp = fp
+                last_heartbeat = now
+                yield _sse("today", body)
+            elif now - last_heartbeat >= SSE_HEARTBEAT_SECS:
+                last_heartbeat = now
+                # Comment-only SSE frame; keeps NAT / proxies from idle-killing.
+                yield ": heartbeat\n\n"
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",  # nginx: don't buffer the stream
+        },
+    )
+
+
+def _sse(event: str, data: str) -> str:
+    """Format a single SSE frame. `data:` lines split on newline per spec."""
+    lines = "\n".join(f"data: {ln}" for ln in data.splitlines() or [""])
+    return f"event: {event}\n{lines}\n\n"
 
 
 @app.get("/shift/{shift_id}", response_class=HTMLResponse)
@@ -225,7 +348,7 @@ def shift_detail(shift_id: str,
     else:
         parts.append("<p class='empty'>No recorded status changes.</p>")
     parts.append('<p><a href="/">&laquo; back to today</a></p>')
-    return HTMLResponse(_layout(s["title"] or "Shift", "\n".join(parts), refresh=True))
+    return HTMLResponse(_layout(s["title"] or "Shift", "\n".join(parts), live=False))
 
 
 @app.get("/offenders", response_class=HTMLResponse)
@@ -249,14 +372,14 @@ def offenders(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)],
                 f"<td>{r['email'] or ''}</td><td>{r['no_shows']}</td></tr>"
             )
         parts.append('</tbody></table>')
-    return HTMLResponse(_layout("Repeat no-shows", "\n".join(parts), refresh=False))
+    return HTMLResponse(_layout("Repeat no-shows", "\n".join(parts), live=False))
 
 
 @app.get("/digest", response_class=HTMLResponse)
 def view_digest(_: Annotated[HTTPBasicCredentials, Depends(_require_auth)], days: int = 1):
     data = digest_mod.collect(days_back=days)
     html = digest_mod.render_html(data)
-    return HTMLResponse(_layout("Digest preview", html, refresh=False))
+    return HTMLResponse(_layout("Digest preview", html, live=False))
 
 
 @app.get("/api/today.json")


### PR DESCRIPTION
## Summary

Reworks the sync layer to track live volunteer check-in / check-out
state (kiosk-source detection -- `hour_status` and `hour_date_end` are
not reliable signals against the Galaxy Digital API), stores everything
in SQLite as a single source of truth, adds a daily HTML email digest
with repeat-offender tracking, ships a FastAPI live web viewer with
SSE push updates, and packages the whole thing as two systemd units
that auto-start on boot. End-to-end verified against a real Galaxy
Digital tenant and a throwaway Google Calendar (RangersTest).

## What's new for the operator

- **`./bootstrap.sh`** -- one-shot venv + deps setup
- **`python verify_galaxy_creds.py`** -- smoke-test API credentials
- **`python initial_ingest.py`** -- populate SQLite once before going live
- **`python preview_production_sync.py`** -- read-only dry-run that prints
  INSERT/UPDATE/NO-OP/ORPHAN counts before the first push to prod
- **`./run_demo_stack.sh`** -- bring up sync + web pointed at a test calendar
- **`python simulate_checkin.py {list,in,out,clear}`** -- forge kiosk events
  locally for soak testing without touching Galaxy Digital
- **`sudo ./setup_galaxy_sync_service.sh`** -- installs `galaxy_sync.service`
  and `galaxy_web.service`, both enabled at boot

Step-by-step deploy procedure is in **DEPLOY.md**.

## What changes for end-users

- Calendar event descriptions use a 5-state palette:
  🔘 signed up · 🟡 checked in · 🟢 checked out · 🟣 manager-entered · 🔴 no-show
  (was 🟡 pending / 🟢 approved / 🔘 nothing.)
- Calendar events now have a **location** field populated from the
  Galaxy `/needs` payload (`need_address/city/state/postal`). Purely
  additive; existing events get one added on next sync.
- Internal-only:
  - Sync cadence: 2h full refresh + 60s scan in shift's ±1h window.
  - Email digest: configurable `DIGEST_SCHEDULE=daily@HH:MM | hourly | off`.
  - Web viewer at `127.0.0.1:8765` (Basic auth, refuses to serve without
    `WEB_PASSWORD`). Live updates via Server-Sent Events.

## Notable bugs caught and fixed

- **Wrong shift attribution**: legacy code joined `/hours` -> shift by
  user_id only. New code uses `hour_response_id` for exact (user, shift)
  match; previously a user with two simultaneous shifts under one need
  could have a check-in mis-attributed.
- **`hour_status` / `hour_date_end` aren't real-time signals**. The only
  reliable signal is the substring of `hour_source` (kiosk Checkin/Checkout
  URLs). Documented in `checkin.py`.
- **Inverted `get_next_shift` / `get_last_shift`** -- the two helpers
  returned each other's answers. Fixed.
- **Silent `KeyError` in `user_checkin_update`** -- a broad
  `except Exception` was swallowing every error with no stack trace.
  Now `logger.exception(...)` so future swallows leave a trail.
- **Silent gcal HTTP 400** on `events().insert()` -- malformed event ids
  (e.g. ones containing `y`, which isn't valid RFC2938 base32hex) were
  logged-and-skipped without raising. Now re-raised.
- **`mark_no_shows` only fired in hot-scan window** -- a shift that
  ended at 8pm without anyone at the kiosk wouldn't be marked no-show
  until the next time we were ±1h of *some* shift. Now also runs at the
  end of every full refresh.

## Test plan

- [x] `pytest tests/` -- 26 unit tests, 1 live gcal roundtrip (skipped
  unless `GCAL_TEST_CALENDAR_ID` is set; passes when it is).
- [x] Live end-to-end: real volunteer (Paul Butler Díaz) checked in at
  Galaxy Digital kiosk, system pulled the `/hours` row, classified him
  via `/kiosk/storeCheckin/`, pushed to RangersTest event 12993551,
  description verified showing 🟡 at his name within ~60s.
- [x] `preview_production_sync.py` against production: reports 0 INSERTs,
  36 UPDATEs (mostly `[location,description]` diffs), 0 NO-OPs, 2 in-
  progress shifts in the orphan-by-window false-positive bucket. No
  duplicates would be created.
- [ ] First production rollout: backup calendar, install systemd units,
  watch journal for the first 2h refresh.
- [ ] Confirm next real check-in propagates to production cal within
  ~60s once the systemd loop is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)