### PR TITLE
Fix gcal "(16/9)" titles: status resolution must go through current_s…

### DIFF
--- a/get_connected.py
+++ b/get_connected.py
@@ -221,22 +221,13 @@ class GalaxyAPI:
                 """,
             ).fetchall()
             for s in shifts:
-                signups = db.signups_for_shift(conn, s["id"])
-                users = []
-                for sg in signups:
-                    users.append({
-                        "id": sg["user_id"],
-                        "response_id": sg["response_id"],
-                        "user_fname": sg["fname"],
-                        "user_lname": sg["lname"],
-                        "user_email": sg["email"],
-                        "checkin_status": sg["classification"] or checkin.SIGNED_UP,
-                    })
+                roster = sync.build_shift_roster(conn, s)
                 # Fingerprint = (slot count, location, user statuses).
                 fp_input = "|".join([
-                    str(s["slots"] or ""),
-                    s["location"] or "",
-                    ",".join(sorted(f"{u['response_id']}:{u['checkin_status']}" for u in users)),
+                    str(roster["slots"] or ""),
+                    roster["location"] or "",
+                    ",".join(sorted(f"{u['response_id']}:{u['checkin_status']}"
+                                    for u in roster["users"])),
                 ])
                 fp = hashlib.sha1(fp_input.encode()).hexdigest()
                 key = f"gcal_fp:{s['id']}"
@@ -244,20 +235,7 @@ class GalaxyAPI:
                 if prev_fp == fp:
                     continue
                 db.set_state(conn, key, fp)
-                tr.append({
-                    "id": s["id"],
-                    "start_time": datetime.strptime(s["start_ts"], "%Y-%m-%d %H:%M:%S"),
-                    "end_time": datetime.strptime(s["end_ts"], "%Y-%m-%d %H:%M:%S"),
-                    "need_id": s["need_id"],
-                    "duration": s["duration_min"],
-                    "slots": s["slots"],
-                    "title": s["title"],
-                    "location": s["location"],
-                    "users": users,
-                    # Cancelled volunteers free their slot; don't count them.
-                    "slots_filled": sum(1 for u in users
-                                        if u.get("checkin_status") != checkin.CANCELLED),
-                })
+                tr.append(roster)
 
         with open("transformed_responses.json", "w") as f:
             json.dump(tr, f, default=str)

--- a/sync.py
+++ b/sync.py
@@ -224,6 +224,46 @@ def mark_no_shows(conn) -> int:
     return written
 
 
+def build_shift_roster(conn, shift_row) -> dict:
+    """Build the dict shape gcal.update_calendar_events expects from a
+    SQLite shift row + its signups.
+
+    Returns: id, start_time, end_time, need_id, duration, slots, title,
+    location, users (list of dicts), slots_filled (excludes cancelled).
+
+    Status for each user goes through current_status_for_signup so
+    cancellations end up as CANCELLED (not signed_up / no_show) and
+    don't inflate the filled count.
+    """
+    from datetime import datetime as _dt
+    users = []
+    for sg in db.signups_for_shift(conn, shift_row["id"]):
+        status = current_status_for_signup(
+            conn, sg["response_id"], sg["user_id"], shift_row["end_ts"],
+        )
+        users.append({
+            "id": sg["user_id"],
+            "response_id": sg["response_id"],
+            "user_fname": sg["fname"],
+            "user_lname": sg["lname"],
+            "user_email": sg["email"],
+            "checkin_status": status,
+        })
+    return {
+        "id": shift_row["id"],
+        "start_time": _dt.strptime(shift_row["start_ts"], "%Y-%m-%d %H:%M:%S"),
+        "end_time":   _dt.strptime(shift_row["end_ts"],   "%Y-%m-%d %H:%M:%S"),
+        "need_id":    shift_row["need_id"] if "need_id" in shift_row.keys() else None,
+        "duration":   shift_row["duration_min"] if "duration_min" in shift_row.keys() else None,
+        "slots":      shift_row["slots"],
+        "title":      shift_row["title"] if "title" in shift_row.keys() else None,
+        "location":   shift_row["location"] if "location" in shift_row.keys() else None,
+        "users": users,
+        "slots_filled": sum(1 for u in users
+                            if u["checkin_status"] != checkin.CANCELLED),
+    }
+
+
 def current_status_for_signup(conn, response_id: str, user_id: str, shift_end: str | None) -> str:
     """Resolve the live status for one signup, with the no-show / signed-up
     distinction made from the shift end-time.

--- a/tests/test_cancelled.py
+++ b/tests/test_cancelled.py
@@ -112,6 +112,46 @@ def test_today_page_filled_count_excludes_cancellations(monkeypatch, tmp_db_path
     assert "2 cancelled" in r.text
 
 
+def test_build_shift_roster_excludes_cancellations_from_filled(db_conn):
+    """Direct unit test of the helper that powers the gcal title.
+
+    Before this fix, a shift with 1 active + 3 cancelled signups produced
+    "(4/N filled)" on the calendar -- because get_connected was reading
+    hour-row classification directly, which is NULL for cancellations
+    and fell back to SIGNED_UP. Now both update_responses and
+    user_checkin_update route through sync.build_shift_roster, which
+    resolves status via current_status_for_signup -- so CANCELLED is
+    detected and slots_filled excludes them.
+    """
+    import checkin, db, sync
+    # 1 active + 3 cancelled on a 4-slot future shift.
+    _ingest(db_conn, rid="r_active",   status="active",   shift_id="s_fill",
+            shift_end_past=False)
+    _ingest(db_conn, rid="r_cancel_1", status="inactive", shift_id="s_fill",
+            shift_end_past=False)
+    _ingest(db_conn, rid="r_cancel_2", status="inactive", shift_id="s_fill",
+            shift_end_past=False)
+    _ingest(db_conn, rid="r_cancel_3", status="inactive", shift_id="s_fill",
+            shift_end_past=False)
+
+    # ingest_response upserts the same shift row each time, so only one
+    # shift exists. Pull it through the same SELECT update_responses uses.
+    shift_row = db_conn.execute(
+        """SELECT s.id, s.start_ts, s.end_ts, s.duration_min, s.slots,
+                  s.need_id, n.title, n.location
+           FROM shifts s LEFT JOIN needs n ON n.id = s.need_id
+           WHERE s.id = ?""",
+        ("s_fill",),
+    ).fetchone()
+    roster = sync.build_shift_roster(db_conn, shift_row)
+    assert roster["slots"] == 4
+    assert roster["slots_filled"] == 1, \
+        f"expected 1 filled (active only), saw {roster['slots_filled']}"
+    statuses = [u["checkin_status"] for u in roster["users"]]
+    assert statuses.count(checkin.CANCELLED) == 3
+    assert sum(1 for s in statuses if s != checkin.CANCELLED) == 1
+
+
 def test_filled_statuses_excludes_cancelled():
     """Belt-and-suspenders: the FILLED_STATUSES tuple must not contain
     CANCELLED. If a future refactor changes this, every "X/Y filled"


### PR DESCRIPTION
…tatus_for_signup

update_responses() in get_connected.py was reading hour-row classification directly:
    "checkin_status": sg["classification"] or checkin.SIGNED_UP
That works for kiosk check-ins and manager-entered hours, but NOT for cancellations -- a cancelled signup has no hour row, so classification is NULL, so it fell back to SIGNED_UP, so it counted toward slots_filled, so the calendar title read "(16/9)" instead of "(7/9)".

user_checkin_update() was already doing this correctly via sync.current_status_for_signup(). Refactored both call sites to use a new sync.build_shift_roster(conn, shift_row) helper so the two paths can't drift apart again.

The fingerprint cache (gcal_fp:<shift_id>) will detect the change on the next sync cycle and push the corrected title; no manual cleanup needed on the server.

Tests: new test_build_shift_roster_excludes_cancellations_from_filled in test_cancelled.py exercises the helper directly with 1 active + 3 cancelled signups and asserts slots_filled=1.